### PR TITLE
Fix issue with site failing to start if adding and removing settings …

### DIFF
--- a/src/AddOn.Episerver.Settings/Core/SettingsService.cs
+++ b/src/AddOn.Episerver.Settings/Core/SettingsService.cs
@@ -365,9 +365,16 @@ namespace AddOn.Episerver.Settings.Core
                 }
 
                 Guid attributeGuid = new Guid(g: attribute.SettingsInstanceGuid);
-                IContent existingItem = existingItems.Any()
-                    ? existingItems.FirstOrDefault(i => i.ContentGuid == attributeGuid)
-                    : this.contentRepository.Get<IContent>(attributeGuid);
+                IContent existingItem = null;
+                
+                if(existingItems.Any())
+                {
+                    existingItem = existingItems.FirstOrDefault(i => i.ContentGuid == attributeGuid);
+                }
+                if(existingItem == null)
+                {
+                    contentRepository.TryGet<IContent>(attributeGuid, out existingItem);
+                }
 
                 if (existingItem == null)
                 {

--- a/src/AddOn.Episerver.Settings/Properties/AssemblyInfo.cs
+++ b/src/AddOn.Episerver.Settings/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]


### PR DESCRIPTION
Use TryGetContent instead of GetContent to fix issue with site initialization error when adding and removing settings at the same time.