### PR TITLE
Changed SettingsService to use a cache that works when using clustered servers

### DIFF
--- a/src/AddOn.Episerver.Settings/Core/SettingsInitializationModule.cs
+++ b/src/AddOn.Episerver.Settings/Core/SettingsInitializationModule.cs
@@ -195,10 +195,7 @@ namespace AddOn.Episerver.Settings.Core
                 return;
             }
 
-            if (e.Content is SettingsBase && e.Content.ParentLink == settingsService.GlobalSettingsRoot)
-            {
-                settingsService.UpdateSettings(content: e.Content);
-            }
+            settingsService.UpdateSettings(e.Content);
         }
     }
 }


### PR DESCRIPTION
Stores the whole global settings dictionary in the sync-cache and when any change is detected on any children of the "Global Settings Root" that are Settings reloads the list. 