### PR TITLE
Added a ContentTypeBaseProvider to enable removing of no longer existing settings types

### DIFF
--- a/src/AddOn.Episerver.Settings/AddOn.Episerver.Settings.csproj
+++ b/src/AddOn.Episerver.Settings/AddOn.Episerver.Settings.csproj
@@ -11,7 +11,7 @@
     <Authors>Linus Ekström, Jeroen Stemerdink</Authors>
     <PackageTags>EpiServer Settings AddOn.Episerver.Settings</PackageTags>
     <PackageProjectUrl>https://github.com/LinusEkstrom/AddOn.Episerver.Settings</PackageProjectUrl>
-    <Version>1.1.1</Version>
+    <Version>1.1.2</Version>
     <Copyright>Copyright © 2021 Linus Ekström, Jeroen Stemerdink</Copyright>
     <Description>A typed replacement of custom built settings systems built on PageData/BlockData.</Description>
   </PropertyGroup>
@@ -25,7 +25,7 @@
     <None Include="readme.txt" pack="true" PackagePath="." />
     <None Include="web.config.install.xdt" pack="true" PackagePath="Content" />
     <None Include="web.config.uninstall.xdt" pack="true" PackagePath="Content" />
-    <None Include="web.config" pack="true" PackageCopyToOutput="true" PackageFlatten="false"  PackagePath="Content\modules\_protected\AddOn.Episerver.Settings" />
+    <None Include="web.config" pack="true" PackageCopyToOutput="true" PackageFlatten="false" PackagePath="Content\modules\_protected\AddOn.Episerver.Settings" />
     <None Include="module.config" pack="true" PackageCopyToOutput="true" PackageFlatten="false" PackagePath="Content\modules\_protected\AddOn.Episerver.Settings" />
     <None Include="module.config" pack="true" PackageCopyToOutput="true" PackageFlatten="false" PackagePath="contentFiles\any\net5.0\modules\_protected\AddOn.Episerver.Settings" />
     <None Include="..\..\templates\SettingsTemplates.DotSettings" pack="true" PackagePath="Tools" />
@@ -41,7 +41,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="EPiServer.CMS.AspNet" Version="[11.1, 12)" />
+	<PackageReference Include="EPiServer.CMS.AspNet" Version="[11.20.7, 12)" />
     <PackageReference Include="EPiServer.CMS.UI.Core" Version="[11.2, 12)" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="4.4.2" />

--- a/src/AddOn.Episerver.Settings/Core/SettingsContentTypeBaseProvider.cs
+++ b/src/AddOn.Episerver.Settings/Core/SettingsContentTypeBaseProvider.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="SettingsBase.cs" company="none">
+// <copyright file="ContentTypeBaseProvider.cs" company="none">
 //      Copyright © 2020 Linus Ekström, Jeroen Stemerdink.
 //      Permission is hereby granted, free of charge, to any person obtaining a copy
 //      of this software and associated documentation files (the "Software"), to deal
@@ -21,45 +21,25 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
+using System;
+using System.Collections.Generic;
+
+using EPiServer.DataAbstraction;
+using EPiServer.DataAbstraction.RuntimeModel;
+using EPiServer.ServiceLocation;
+
 namespace AddOn.Episerver.Settings.Core
 {
-    using System;
-
-    using EPiServer.Core;
-    using EPiServer.DataAnnotations;
-
-    /// <summary>
-    /// Class SettingsBase.
-    /// Implements the <see cref="BasicContent" />
-    /// Implements the <see cref="IVersionable" />
-    /// </summary>
-    /// <seealso cref="BasicContent" />
-    /// <seealso cref="IVersionable" />
-    [ContentType(GUID = "484DAD32-3E16-4943-B7BF-A542C7BDC379", AvailableInEditMode = false)]
-    public class SettingsBase : BasicContent, IVersionable
+    [ServiceConfiguration(typeof (IContentTypeBaseProvider), Lifecycle = ServiceInstanceScope.Singleton)]
+    public class SettingsContentTypeBaseProvider : IContentTypeBaseProvider
     {
-        /// <summary>
-        /// Gets or sets a value indicating whether this item is in pending publish state.
-        /// </summary>
-        /// <value><c>true</c> if this instance is in pending publish state; otherwise, <c>false</c>.</value>
-        public bool IsPendingPublish { get; set; }
+        private static readonly ContentTypeBase SettingContentType = new ContentTypeBase("Setting");
 
-        /// <summary>
-        /// Gets or sets the start publish date for this item.
-        /// </summary>
-        /// <value>The start publish.</value>
-        public DateTime? StartPublish { get; set; }
+        public IEnumerable<ContentTypeBase> ContentTypeBases => new [] { SettingContentType };
 
-        /// <summary>
-        /// Gets or sets the version status of this item.
-        /// </summary>
-        /// <value>The status.</value>
-        public VersionStatus Status { get; set; }
-
-        /// <summary>
-        /// Gets or sets the stop publish date for this item.
-        /// </summary>
-        /// <value>The stop publish.</value>
-        public DateTime? StopPublish { get; set; }
+        public Type Resolve(ContentTypeBase contentTypeBase)
+        {
+            return typeof(SettingsBase);
+        }
     }
 }

--- a/src/AddOn.Episerver.Settings/Core/SettingsInitializationModule.cs
+++ b/src/AddOn.Episerver.Settings/Core/SettingsInitializationModule.cs
@@ -145,12 +145,14 @@ namespace AddOn.Episerver.Settings.Core
         /// <param name="e">The <see cref="DeleteContentEventArgs"/> instance containing the event data.</param>
         private static void DeletingContent(object sender, DeleteContentEventArgs e)
         {
-            if (e == null)
+            if (e == null || e.Content == null)
             {
                 return;
             }
 
-            if (!(e.Content is SettingsBase) || e.Content.ParentLink != settingsService.GlobalSettingsRoot)
+            // if the content item is an instance of SettingsBase, it has been instantiated with the fallback base class
+            // since the ContentType class no longer exists and should be possible to delete
+            if (e.Content.GetOriginalType() == typeof(SettingsBase)  || !(e.Content is SettingsBase) || e.Content.ParentLink != settingsService.GlobalSettingsRoot)
             {
                 return;
             }
@@ -182,8 +184,10 @@ namespace AddOn.Episerver.Settings.Core
                 return;
             }
 
-            if (!(e.Content is SettingsBase) || e.Content.ParentLink != settingsService.GlobalSettingsRoot
-                                             || e.TargetLink.ID != 2)
+            // if the content item is an instance of SettingsBase, it has been instantiated with the fallback base class
+            // since the ContentType class no longer exists and should be possible to move to the waste basket
+            if (e.Content.GetOriginalType() == typeof(SettingsBase) || !(e.Content is SettingsBase) || e.Content.ParentLink != settingsService.GlobalSettingsRoot
+                || e.TargetLink.ID != 2)
             {
                 return;
             }

--- a/src/AddOn.Episerver.Settings/Core/SettingsService.cs
+++ b/src/AddOn.Episerver.Settings/Core/SettingsService.cs
@@ -396,7 +396,9 @@ namespace AddOn.Episerver.Settings.Core
                     this.log.Error($"[Settings] {ex.Message}", exception: ex);
                 }
 
-                if (item != null)
+                // If the item is an instance of SettingsBase has been loaded as a fallback 
+                // because the ContentType class no longer exists
+                if (item != null && item.GetOriginalType() != typeof(SettingsBase))
                 {
                     yield return item;
                 }


### PR DESCRIPTION
Also made the SettingsBase a ContentType, since it was needed for the UI to handle
instances that no longer are backed by code.

Also changed the logic for stopping deletion of settings so that it is now possible
to delete Settings that no longer are backed by code.

Resolves: #22