### PR TITLE
If Commerce is installed it's client module should be initialized the global settings view

### DIFF
--- a/src/AddOn.Episerver.Settings/AddOn.Episerver.Settings.csproj
+++ b/src/AddOn.Episerver.Settings/AddOn.Episerver.Settings.csproj
@@ -3,6 +3,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>AddOn.Episerver.Settings</RootNamespace>
     <AssemblyName>AddOn.Episerver.Settings</AssemblyName>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>net461;net5.0</TargetFrameworks>


### PR DESCRIPTION
This fix adds the EPiServer.Commerce.Shell module to be started alongside settings it it is installed,

Fixes: #27