### PR TITLE
Moves usings outside of namespace, cleans up and formats code

### DIFF
--- a/src/AddOn.Episerver.Settings/AddOn.Episerver.Settings.csproj
+++ b/src/AddOn.Episerver.Settings/AddOn.Episerver.Settings.csproj
@@ -4,8 +4,9 @@
     <RootNamespace>AddOn.Episerver.Settings</RootNamespace>
     <AssemblyName>AddOn.Episerver.Settings</AssemblyName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>3.0.0</PackageVersion>
-    <TargetFrameworks>net461;net5.0;net6.0;net7.0</TargetFrameworks>
+    <PackageVersion>4.0.0</PackageVersion>
+    <LangVersion>10</LangVersion>
+    <TargetFrameworks>net48;net5.0;net6.0;net7.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <DebugType>embedded</DebugType>
     <Authors>Linus Ekström, Jeroen Stemerdink, Erik Kärrsgård</Authors>
@@ -18,41 +19,39 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Resources\*.xml" />
+    <EmbeddedResource Include="Resources\*.xml"/>
   </ItemGroup>
   <ItemGroup>
-    <None Include="readme.txt" pack="true" PackagePath="." />
-    <None Include="web.config.install.xdt" pack="true" PackagePath="Content" />
-    <None Include="web.config.uninstall.xdt" pack="true" PackagePath="Content" />
-    <None Include="web.config" pack="true" PackageCopyToOutput="true" PackageFlatten="false" PackagePath="Content\modules\_protected\AddOn.Episerver.Settings" />
-    <None Include="AddOn.Episerver.Settings.zip" pack="true" PackageCopyToOutput="true" PackageFlatten="false" PackagePath="Content\modules\_protected\AddOn.Episerver.Settings" />
-    <None Include="AddOn.Episerver.Settings.zip" pack="true" PackageCopyToOutput="true" PackageFlatten="false" PackagePath="contentFiles\any\any\modules\_protected\AddOn.Episerver.Settings" />
-    <None Include="..\..\templates\SettingsTemplates.DotSettings" pack="true" PackagePath="Tools" />
-    <None Include="AddOn.Episerver.Settings.targets" pack="true" PackagePath="Build\net5.0" />
-    <None Include="AddOn.Episerver.Settings.targets" pack="true" PackagePath="Build\net6.0" />
-    <None Include="AddOn.Episerver.Settings.targets" pack="true" PackagePath="Build\net7.0" />
+    <None Include="readme.txt" pack="true" PackagePath="."/>
+    <None Include="web.config.install.xdt" pack="true" PackagePath="Content"/>
+    <None Include="web.config.uninstall.xdt" pack="true" PackagePath="Content"/>
+    <None Include="web.config" pack="true" PackageCopyToOutput="true" PackageFlatten="false" PackagePath="Content\modules\_protected\AddOn.Episerver.Settings"/>
+    <None Include="AddOn.Episerver.Settings.zip" pack="true" PackageCopyToOutput="true" PackageFlatten="false" PackagePath="Content\modules\_protected\AddOn.Episerver.Settings"/>
+    <None Include="AddOn.Episerver.Settings.zip" pack="true" PackageCopyToOutput="true" PackageFlatten="false" PackagePath="contentFiles\any\any\modules\_protected\AddOn.Episerver.Settings"/>
+    <None Include="..\..\templates\SettingsTemplates.DotSettings" pack="true" PackagePath="Tools"/>
+    <None Include="AddOn.Episerver.Settings.targets" pack="true" PackagePath="Build\net5.0"/>
+    <None Include="AddOn.Episerver.Settings.targets" pack="true" PackagePath="Build\net6.0"/>
+    <None Include="AddOn.Episerver.Settings.targets" pack="true" PackagePath="Build\net7.0"/>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="EPiServer.CMS.AspNet" Version="[11.20.7, 12)" />
-    <PackageReference Include="EPiServer.CMS.UI.Core" Version="[11.2, 12)" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+    <PackageReference Include="EPiServer.CMS.AspNet" Version="[11.20.7, 12)"/>
+    <PackageReference Include="EPiServer.CMS.UI.Core" Version="[11.2, 12)"/>
+    <Reference Include="System.Web.ApplicationServices"/>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="EPiServer.CMS.AspNetCore.Templating" Version="[12.0.3, 13)" />
-    <PackageReference Include="EPiServer.CMS.UI.Core" Version="[12.0.2, 13)" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="EPiServer.CMS.AspNetCore.Templating" Version="[12.0.3, 13)"/>
+    <PackageReference Include="EPiServer.CMS.UI.Core" Version="[12.0.2, 13)"/>
+    <FrameworkReference Include="Microsoft.AspNetCore.App"/>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="EPiServer.CMS.AspNetCore.Templating" Version="[12.4.2, 13)" />
-    <PackageReference Include="EPiServer.CMS.UI.Core" Version="[12.5.0, 13)" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="EPiServer.CMS.AspNetCore.Templating" Version="[12.4.2, 13)"/>
+    <PackageReference Include="EPiServer.CMS.UI.Core" Version="[12.5.0, 13)"/>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0"/>
+    <FrameworkReference Include="Microsoft.AspNetCore.App"/>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="EPiServer.CMS.AspNetCore.Templating" Version="[12.4.2, 13)" />
-    <PackageReference Include="EPiServer.CMS.UI.Core" Version="[12.5.0, 13)" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="EPiServer.CMS.AspNetCore.Templating" Version="[12.4.2, 13)"/>
+    <PackageReference Include="EPiServer.CMS.UI.Core" Version="[12.5.0, 13)"/>
+    <FrameworkReference Include="Microsoft.AspNetCore.App"/>
   </ItemGroup>
 </Project>

--- a/src/AddOn.Episerver.Settings/AddOn.Episerver.Settings.csproj
+++ b/src/AddOn.Episerver.Settings/AddOn.Episerver.Settings.csproj
@@ -6,7 +6,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageVersion>4.0.0</PackageVersion>
     <LangVersion>10</LangVersion>
-    <TargetFrameworks>net48;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0;net7.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <DebugType>embedded</DebugType>
     <Authors>Linus Ekström, Jeroen Stemerdink, Erik Kärrsgård</Authors>
@@ -29,7 +29,6 @@
     <None Include="AddOn.Episerver.Settings.zip" pack="true" PackageCopyToOutput="true" PackageFlatten="false" PackagePath="Content\modules\_protected\AddOn.Episerver.Settings"/>
     <None Include="AddOn.Episerver.Settings.zip" pack="true" PackageCopyToOutput="true" PackageFlatten="false" PackagePath="contentFiles\any\any\modules\_protected\AddOn.Episerver.Settings"/>
     <None Include="..\..\templates\SettingsTemplates.DotSettings" pack="true" PackagePath="Tools"/>
-    <None Include="AddOn.Episerver.Settings.targets" pack="true" PackagePath="Build\net5.0"/>
     <None Include="AddOn.Episerver.Settings.targets" pack="true" PackagePath="Build\net6.0"/>
     <None Include="AddOn.Episerver.Settings.targets" pack="true" PackagePath="Build\net7.0"/>
   </ItemGroup>
@@ -38,15 +37,9 @@
     <PackageReference Include="EPiServer.CMS.UI.Core" Version="[11.2, 12)"/>
     <Reference Include="System.Web.ApplicationServices"/>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="EPiServer.CMS.AspNetCore.Templating" Version="[12.0.3, 13)"/>
-    <PackageReference Include="EPiServer.CMS.UI.Core" Version="[12.0.2, 13)"/>
-    <FrameworkReference Include="Microsoft.AspNetCore.App"/>
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="EPiServer.CMS.AspNetCore.Templating" Version="[12.4.2, 13)"/>
     <PackageReference Include="EPiServer.CMS.UI.Core" Version="[12.5.0, 13)"/>
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0"/>
     <FrameworkReference Include="Microsoft.AspNetCore.App"/>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">

--- a/src/AddOn.Episerver.Settings/Core/DeterministicGuid.cs
+++ b/src/AddOn.Episerver.Settings/Core/DeterministicGuid.cs
@@ -3,45 +3,49 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 
-namespace AddOn.Episerver.Settings.Core
+namespace AddOn.Episerver.Settings.Core;
+
+internal static class DeterministicGuid
 {
-    internal static class DeterministicGuid
+    /// <summary>
+    ///     Creates a name-based UUID using the algorithm from RFC 4122 §4.3.
+    ///     Slimmed down version of:
+    ///     https://github.com/Faithlife/FaithlifeUtility/blob/master/src/Faithlife.Utility/GuidUtility.cs
+    /// </summary>
+    /// <param name="namespaceId">The ID of the namespace.</param>
+    /// <param name="name">The name (within that namespace).</param>
+    /// <returns>A UUID derived from the namespace and name.</returns>
+    internal static Guid Create(Guid namespaceId, string name)
     {
-        /// <summary>
-        /// Creates a name-based UUID using the algorithm from RFC 4122 §4.3.
-        /// Slimmed down version of: https://github.com/Faithlife/FaithlifeUtility/blob/master/src/Faithlife.Utility/GuidUtility.cs
-        /// </summary>
-        /// <param name="namespaceId">The ID of the namespace.</param>
-        /// <param name="name">The name (within that namespace).</param>
-        /// <returns>A UUID derived from the namespace and name.</returns>
-        internal static Guid Create(Guid namespaceId, string name)
+        var nameBytes = Encoding.UTF8.GetBytes(name);
+        var namespaceBytes = namespaceId.ToByteArray();
+        SwapByteOrder(namespaceBytes);
+        var data = namespaceBytes.Concat(nameBytes).ToArray();
+        byte[] hash;
+        using (var algorithm = SHA1.Create())
         {
-            var nameBytes = Encoding.UTF8.GetBytes(name);
-            var namespaceBytes = namespaceId.ToByteArray();
-            SwapByteOrder(namespaceBytes);
-            var data = namespaceBytes.Concat(nameBytes).ToArray();
-            byte[] hash;
-            using (var algorithm = SHA1.Create()) hash = algorithm.ComputeHash(data);
-            var newGuid = new byte[16];
-            Array.Copy(hash, 0, newGuid, 0, 16);
-            newGuid[6] = (byte) (newGuid[6] & 0x0F | 5 << 4);
-            newGuid[8] = (byte) (newGuid[8] & 0x3F | 0x80);
-            SwapByteOrder(newGuid);
-            
-            return new Guid(newGuid);
+            hash = algorithm.ComputeHash(data);
         }
-        
-        private static void SwapByteOrder(byte[] guid)
-        {
-            SwapBytes(guid, 0, 3);
-            SwapBytes(guid, 1, 2);
-            SwapBytes(guid, 4, 5);
-            SwapBytes(guid, 6, 7);
-        }
-        
-        private static void SwapBytes(byte[] guid, int left, int right)
-        {
-            (guid[left], guid[right]) = (guid[right], guid[left]);
-        }
+
+        var newGuid = new byte[16];
+        Array.Copy(hash, 0, newGuid, 0, 16);
+        newGuid[6] = (byte)(newGuid[6] & 0x0F | 5 << 4);
+        newGuid[8] = (byte)(newGuid[8] & 0x3F | 0x80);
+        SwapByteOrder(newGuid);
+
+        return new Guid(newGuid);
+    }
+
+    private static void SwapByteOrder(byte[] guid)
+    {
+        SwapBytes(guid, 0, 3);
+        SwapBytes(guid, 1, 2);
+        SwapBytes(guid, 4, 5);
+        SwapBytes(guid, 6, 7);
+    }
+
+    private static void SwapBytes(byte[] guid, int left, int right)
+    {
+        (guid[left], guid[right]) = (guid[right], guid[left]);
     }
 }

--- a/src/AddOn.Episerver.Settings/Core/ISettingsService.cs
+++ b/src/AddOn.Episerver.Settings/Core/ISettingsService.cs
@@ -21,75 +21,73 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace AddOn.Episerver.Settings.Core
-{
-    using System;
-    using System.Collections.Generic;
+using EPiServer.Core;
+using EPiServer.Web;
+using System;
+using System.Collections.Generic;
 
-    using EPiServer.Core;
-    using EPiServer.Web;
+namespace AddOn.Episerver.Settings.Core;
+
+/// <summary>
+///     Interface ISettingsService
+/// </summary>
+public interface ISettingsService
+{
+    /// <summary>
+    ///     Gets the global settings.
+    /// </summary>
+    /// <value>The global settings.</value>
+    Dictionary<Type, ContentReference> GlobalSettings { get; }
 
     /// <summary>
-    /// Interface ISettingsService
+    ///     Gets or sets the global settings root.
     /// </summary>
-    public interface ISettingsService
-    {
-        /// <summary>
-        /// Gets the global settings.
-        /// </summary>
-        /// <value>The global settings.</value>
-        Dictionary<Type, ContentReference> GlobalSettings { get; }
+    /// <value>The global settings root.</value>
+    ContentReference GlobalSettingsRoot { get; set; }
 
-        /// <summary>
-        /// Gets or sets the global settings root.
-        /// </summary>
-        /// <value>The global settings root.</value>
-        ContentReference GlobalSettingsRoot { get; set; }
-        
-        /// <summary>
-        /// Gets or sets the settings root.
-        /// </summary>
-        /// <value>The settings root.</value>
-        ContentReference SettingsRoot { get; set; }
-        
-        /// <summary>
-        /// Gets the settings roots.
-        /// </summary>
-        /// <value>The settings roots.</value>
-        IEnumerable<ContentReference> SettingsRoots { get; }
-        
-        /// <summary>
-        /// Gets the settings.
-        /// </summary>
-        /// <typeparam name="T">The settings type</typeparam>
-        /// <returns>An instance of <typeparamref name="T" /></returns>
-        T GetSettings<T>() where T : IContent;
+    /// <summary>
+    ///     Gets or sets the settings root.
+    /// </summary>
+    /// <value>The settings root.</value>
+    ContentReference SettingsRoot { get; set; }
 
-        /// <summary>
-        /// Gets the settings.
-        /// </summary>
-        /// <typeparam name="T">The settings type</typeparam>
-        /// <param name="content">The content.</param>
-        /// <returns>An instance of <typeparamref name="T" /></returns>
-        T GetSettings<T>(IContent content)
-            where T : IContent;
+    /// <summary>
+    ///     Gets the settings roots.
+    /// </summary>
+    /// <value>The settings roots.</value>
+    IEnumerable<ContentReference> SettingsRoots { get; }
 
-        /// <summary>
-        /// Initializes the settings.
-        /// </summary>
-        /// <exception cref="T:System.NotSupportedException">If the root name is already registered with another contentRootId.</exception>
-        void InitSettings();
+    /// <summary>
+    ///     Gets the settings.
+    /// </summary>
+    /// <typeparam name="T">The settings type</typeparam>
+    /// <returns>An instance of <typeparamref name="T" /></returns>
+    T GetSettings<T>() where T : IContent;
 
-        /// <summary>
-        /// Updates the settings.
-        /// </summary>
-        /// <param name="content">The content.</param>
-        void UpdateSettings(IContent content);
+    /// <summary>
+    ///     Gets the settings.
+    /// </summary>
+    /// <typeparam name="T">The settings type</typeparam>
+    /// <param name="content">The content.</param>
+    /// <returns>An instance of <typeparamref name="T" /></returns>
+    T GetSettings<T>(IContent content)
+        where T : IContent;
 
-        /// <summary>
-        /// Updates the settings root folder for a site.
-        /// </summary>
-        /// <param name="SiteDefinition">The site definition.</param>
-        ContentReference ValidateOrCreateSiteSettingsRoot(SiteDefinition siteDefinition);
-    }
+    /// <summary>
+    ///     Initializes the settings.
+    /// </summary>
+    /// <exception cref="T:System.NotSupportedException">If the root name is already registered with another contentRootId.</exception>
+    void InitSettings();
+
+    /// <summary>
+    ///     Updates the settings.
+    /// </summary>
+    /// <param name="content">The content.</param>
+    void UpdateSettings(IContent content);
+
+    /// <summary>
+    ///     Updates the settings root folder for a site.
+    /// </summary>
+    /// <param name="SiteDefinition">The site definition.</param>
+    ContentReference ValidateOrCreateSiteSettingsRoot(SiteDefinition siteDefinition);
 }

--- a/src/AddOn.Episerver.Settings/Core/LocalizableSettingsBase.cs
+++ b/src/AddOn.Episerver.Settings/Core/LocalizableSettingsBase.cs
@@ -21,38 +21,36 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace AddOn.Episerver.Settings.Core
-{
-    using System.Collections.Generic;
-    using System.Globalization;
+using EPiServer.Core;
+using System.Collections.Generic;
+using System.Globalization;
 
-    using EPiServer.Core;
+namespace AddOn.Episerver.Settings.Core;
+
+/// <summary>
+///     Class LocalizableSettingsBase.
+///     Implements the <see cref="SettingsBase" />
+///     Implements the <see cref="ILocalizable" />
+/// </summary>
+/// <seealso cref="SettingsBase" />
+/// <seealso cref="ILocalizable" />
+public class LocalizableSettingsBase : SettingsBase, ILocalizable
+{
+    /// <summary>
+    ///     Gets or sets the existing languages for the <see cref="T:EPiServer.Core.ContentData" />
+    /// </summary>
+    /// <value>The existing languages.</value>
+    public IEnumerable<CultureInfo> ExistingLanguages { get; set; }
 
     /// <summary>
-    /// Class LocalizableSettingsBase.
-    /// Implements the <see cref="SettingsBase" />
-    /// Implements the <see cref="ILocalizable" />
+    ///     Gets or sets the language for this instance (typically a <see cref="T:EPiServer.Core.ContentData" /> instance).
     /// </summary>
-    /// <seealso cref="SettingsBase" />
-    /// <seealso cref="ILocalizable" />
-    public class LocalizableSettingsBase : SettingsBase, ILocalizable
-    {
-        /// <summary>
-        /// Gets or sets the existing languages for the <see cref="T:EPiServer.Core.ContentData" />
-        /// </summary>
-        /// <value>The existing languages.</value>
-        public IEnumerable<CultureInfo> ExistingLanguages { get; set; }
+    /// <value>The language.</value>
+    public CultureInfo Language { get; set; }
 
-        /// <summary>
-        /// Gets or sets the language for this instance (typically a <see cref="T:EPiServer.Core.ContentData" /> instance).
-        /// </summary>
-        /// <value>The language.</value>
-        public CultureInfo Language { get; set; }
-
-        /// <summary>
-        /// Gets or sets the master language for this <see cref="T:EPiServer.Core.ContentData" /> instance.
-        /// </summary>
-        /// <value>The master language.</value>
-        public CultureInfo MasterLanguage { get; set; }
-    }
+    /// <summary>
+    ///     Gets or sets the master language for this <see cref="T:EPiServer.Core.ContentData" /> instance.
+    /// </summary>
+    /// <value>The master language.</value>
+    public CultureInfo MasterLanguage { get; set; }
 }

--- a/src/AddOn.Episerver.Settings/Core/SettingsBase.cs
+++ b/src/AddOn.Episerver.Settings/Core/SettingsBase.cs
@@ -21,45 +21,43 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace AddOn.Episerver.Settings.Core
-{
-    using System;
+using EPiServer.Core;
+using EPiServer.DataAnnotations;
+using System;
 
-    using EPiServer.Core;
-    using EPiServer.DataAnnotations;
+namespace AddOn.Episerver.Settings.Core;
+
+/// <summary>
+///     Class SettingsBase.
+///     Implements the <see cref="BasicContent" />
+///     Implements the <see cref="IVersionable" />
+/// </summary>
+/// <seealso cref="BasicContent" />
+/// <seealso cref="IVersionable" />
+[ContentType(GUID = "484DAD32-3E16-4943-B7BF-A542C7BDC379", AvailableInEditMode = false)]
+public class SettingsBase : BasicContent, IVersionable
+{
+    /// <summary>
+    ///     Gets or sets a value indicating whether this item is in pending publish state.
+    /// </summary>
+    /// <value><c>true</c> if this instance is in pending publish state; otherwise, <c>false</c>.</value>
+    public bool IsPendingPublish { get; set; }
 
     /// <summary>
-    /// Class SettingsBase.
-    /// Implements the <see cref="BasicContent" />
-    /// Implements the <see cref="IVersionable" />
+    ///     Gets or sets the start publish date for this item.
     /// </summary>
-    /// <seealso cref="BasicContent" />
-    /// <seealso cref="IVersionable" />
-    [ContentType(GUID = "484DAD32-3E16-4943-B7BF-A542C7BDC379", AvailableInEditMode = false)]
-    public class SettingsBase : BasicContent, IVersionable
-    {
-        /// <summary>
-        /// Gets or sets a value indicating whether this item is in pending publish state.
-        /// </summary>
-        /// <value><c>true</c> if this instance is in pending publish state; otherwise, <c>false</c>.</value>
-        public bool IsPendingPublish { get; set; }
+    /// <value>The start publish.</value>
+    public DateTime? StartPublish { get; set; }
 
-        /// <summary>
-        /// Gets or sets the start publish date for this item.
-        /// </summary>
-        /// <value>The start publish.</value>
-        public DateTime? StartPublish { get; set; }
+    /// <summary>
+    ///     Gets or sets the version status of this item.
+    /// </summary>
+    /// <value>The status.</value>
+    public VersionStatus Status { get; set; }
 
-        /// <summary>
-        /// Gets or sets the version status of this item.
-        /// </summary>
-        /// <value>The status.</value>
-        public VersionStatus Status { get; set; }
-
-        /// <summary>
-        /// Gets or sets the stop publish date for this item.
-        /// </summary>
-        /// <value>The stop publish.</value>
-        public DateTime? StopPublish { get; set; }
-    }
+    /// <summary>
+    ///     Gets or sets the stop publish date for this item.
+    /// </summary>
+    /// <value>The stop publish.</value>
+    public DateTime? StopPublish { get; set; }
 }

--- a/src/AddOn.Episerver.Settings/Core/SettingsContentTypeAttribute.cs
+++ b/src/AddOn.Episerver.Settings/Core/SettingsContentTypeAttribute.cs
@@ -21,30 +21,28 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace AddOn.Episerver.Settings.Core
-{
-    using System;
+using EPiServer.DataAnnotations;
+using System;
 
-    using EPiServer.DataAnnotations;
+namespace AddOn.Episerver.Settings.Core;
+
+/// <summary>
+///     Class SettingsContentTypeAttribute. This class cannot be inherited.
+///     Implements the <see cref="ContentTypeAttribute" />
+/// </summary>
+/// <seealso cref="ContentTypeAttribute" />
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class SettingsContentTypeAttribute : ContentTypeAttribute
+{
+    /// <summary>
+    ///     Gets or sets the settings instance unique identifier.
+    /// </summary>
+    /// <value>The settings instance unique identifier.</value>
+    public string SettingsInstanceGuid { get; set; }
 
     /// <summary>
-    /// Class SettingsContentTypeAttribute. This class cannot be inherited.
-    /// Implements the <see cref="ContentTypeAttribute" />
+    ///     Gets or sets the name of the settings.
     /// </summary>
-    /// <seealso cref="ContentTypeAttribute" />
-    [AttributeUsage(validOn: AttributeTargets.Class)]
-    public sealed class SettingsContentTypeAttribute : ContentTypeAttribute
-    {
-        /// <summary>
-        /// Gets or sets the settings instance unique identifier.
-        /// </summary>
-        /// <value>The settings instance unique identifier.</value>
-        public string SettingsInstanceGuid { get; set; }
-
-        /// <summary>
-        /// Gets or sets the name of the settings.
-        /// </summary>
-        /// <value>The name of the settings.</value>
-        public string SettingsName { get; set; }
-    }
+    /// <value>The name of the settings.</value>
+    public string SettingsName { get; set; }
 }

--- a/src/AddOn.Episerver.Settings/Core/SettingsContentTypeBaseProvider.cs
+++ b/src/AddOn.Episerver.Settings/Core/SettingsContentTypeBaseProvider.cs
@@ -21,25 +21,23 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-
 using EPiServer.DataAbstraction;
 using EPiServer.DataAbstraction.RuntimeModel;
 using EPiServer.ServiceLocation;
+using System;
+using System.Collections.Generic;
 
-namespace AddOn.Episerver.Settings.Core
+namespace AddOn.Episerver.Settings.Core;
+
+[ServiceConfiguration(typeof(IContentTypeBaseProvider), Lifecycle = ServiceInstanceScope.Singleton)]
+public class SettingsContentTypeBaseProvider : IContentTypeBaseProvider
 {
-    [ServiceConfiguration(typeof (IContentTypeBaseProvider), Lifecycle = ServiceInstanceScope.Singleton)]
-    public class SettingsContentTypeBaseProvider : IContentTypeBaseProvider
+    private static readonly ContentTypeBase SettingContentType = new ContentTypeBase("Setting");
+
+    public IEnumerable<ContentTypeBase> ContentTypeBases => new[] { SettingContentType };
+
+    public Type Resolve(ContentTypeBase contentTypeBase)
     {
-        private static readonly ContentTypeBase SettingContentType = new ContentTypeBase("Setting");
-
-        public IEnumerable<ContentTypeBase> ContentTypeBases => new [] { SettingContentType };
-
-        public Type Resolve(ContentTypeBase contentTypeBase)
-        {
-            return typeof(SettingsBase);
-        }
+        return typeof(SettingsBase);
     }
 }

--- a/src/AddOn.Episerver.Settings/Core/SettingsInitializationModule.cs
+++ b/src/AddOn.Episerver.Settings/Core/SettingsInitializationModule.cs
@@ -21,227 +21,240 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace AddOn.Episerver.Settings.Core
-{
-    using System;
-    using System.Linq;
-    using EPiServer;
-    using EPiServer.Core;
-    using EPiServer.Framework;
-    using EPiServer.Framework.Initialization;
-    using EPiServer.Framework.Localization;
-    using EPiServer.ServiceLocation;
-    using EPiServer.Shell.Configuration;
-    using EPiServer.Shell.Modules;
-    using EPiServer.Web;
-#if NET461
+using EPiServer;
+using EPiServer.Core;
+using EPiServer.Framework;
+using EPiServer.Framework.Initialization;
+using EPiServer.Framework.Localization;
+using EPiServer.ServiceLocation;
+using EPiServer.Shell.Configuration;
+using EPiServer.Shell.Modules;
+using EPiServer.Web;
+using System;
+using System.Linq;
+using InitializationModule = EPiServer.Web.InitializationModule;
+
+namespace AddOn.Episerver.Settings.Core;
+#if NET48
 #else
     using Microsoft.Extensions.DependencyInjection;
 #endif
-    using InitializationModule = EPiServer.Web.InitializationModule;
 
-    /// <summary>
-    /// Class SettingsInit.
-    /// </summary>
-    /// <seealso cref="IInitializableModule" />
-    /// <author>Jeroen Stemerdink</author>
-    [InitializableModule]
-    [ModuleDependency(typeof(InitializationModule))]
-    public class SettingsInitializationModule : IConfigurableModule
+/// <summary>
+///     Class SettingsInit.
+/// </summary>
+/// <seealso cref="IInitializableModule" />
+/// <author>Jeroen Stemerdink</author>
+[InitializableModule]
+[ModuleDependency(typeof(InitializationModule))]
+public class SettingsInitializationModule : IConfigurableModule
+{
+    private static IContentEvents contentEvents;
+
+    private static ISiteDefinitionEvents siteDefinitionEvents;
+
+    private static bool initialized;
+
+    private static LocalizationService localizationService;
+
+    private static ISettingsService settingsService;
+
+    /// <summary>Configure the IoC container before initialization.</summary>
+    /// <param name="context">The context on which the container can be accessed.</param>
+    public void ConfigureContainer(ServiceConfigurationContext context)
     {
-        private static IContentEvents contentEvents;
-        
-        private static ISiteDefinitionEvents siteDefinitionEvents;
-
-        private static bool initialized;
-
-        private static LocalizationService localizationService;
-
-        private static ISettingsService settingsService;
-
-        /// <summary>Configure the IoC container before initialization.</summary>
-        /// <param name="context">The context on which the container can be accessed.</param>
-        public void ConfigureContainer(ServiceConfigurationContext context)
+        if (context == null)
         {
-            if (context == null)
-            {
-                return;
-            }
+            return;
+        }
 
-#if NET461
-            IServiceConfigurationProvider services = context.Services;
-            services.AddSingleton<ISettingsService, SettingsService>();
+#if NET48
+        var services = context.Services;
+        services.AddSingleton<ISettingsService, SettingsService>();
 #else
             context.Services.AddSingleton<ISettingsService, SettingsService>();
             context.Services.Configure<ProtectedModuleOptions>(pm => pm.Items.Add(new ModuleDetails() { Name = "AddOn.Episerver.Settings" }));
 #endif
-        }
+    }
 
-        /// <summary>
-        /// Initializes this instance.
-        /// </summary>
-        /// <param name="context">The context.</param>
-        /// <remarks>Gets called as part of the EPiServer Framework initialization sequence. Note that it will be called
-        /// only once per AppDomain, unless the method throws an exception. If an exception is thrown, the initialization
-        /// method will be called repeatedly for each request reaching the site until the method succeeds.</remarks>
-        /// <exception cref="T:EPiServer.ServiceLocation.ActivationException">if there is are errors resolving the service instance.</exception>
-        public void Initialize(InitializationEngine context)
+    /// <summary>
+    ///     Initializes this instance.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    /// <remarks>
+    ///     Gets called as part of the EPiServer Framework initialization sequence. Note that it will be called
+    ///     only once per AppDomain, unless the method throws an exception. If an exception is thrown, the initialization
+    ///     method will be called repeatedly for each request reaching the site until the method succeeds.
+    /// </remarks>
+    /// <exception cref="T:EPiServer.ServiceLocation.ActivationException">
+    ///     if there is are errors resolving the service
+    ///     instance.
+    /// </exception>
+    public void Initialize(InitializationEngine context)
+    {
+        if (context == null || context.HostType != HostType.WebApplication)
         {
-            if ((context == null) || (context.HostType != HostType.WebApplication))
-            {
-                return;
-            }
-
-            if (initialized)
-            {
-                return;
-            }
-            
-            context.InitComplete += (sender, args) =>
-            {
-                var moduleTable = context.Locate.Advanced.GetInstance<ModuleTable>();
-                var modules = moduleTable.GetModules().ToList();
-                var settings = modules.FirstOrDefault(m => string.Equals(m.Name, "AddOn.Episerver.Settings", StringComparison.OrdinalIgnoreCase));
-                var commerce = modules.FirstOrDefault(m =>  string.Equals(m.Name, "EPiServer.Commerce.Shell", StringComparison.OrdinalIgnoreCase));
-
-                if (settings != null && commerce != null)
-                {
-                    settings.Manifest.ClientModule.ModuleDependencies.Add(new ModuleDependency { Dependency = "EPiServer.Commerce.Shell", DependencyType = ModuleDependencyTypes.Require | ModuleDependencyTypes.RunAfter });
-                }
-            };
-
-            settingsService = context.Locate.Advanced.GetInstance<ISettingsService>();
-            contentEvents = context.Locate.Advanced.GetInstance<IContentEvents>();
-            siteDefinitionEvents = context.Locate.Advanced.GetInstance<ISiteDefinitionEvents>();
-            localizationService = context.Locate.Advanced.GetInstance<LocalizationService>();
-
-            context.InitComplete += InitCompleteHandler;
-
-            contentEvents.PublishedContent += PublishedContent;
-            contentEvents.MovingContent += MovingContent;
-            contentEvents.DeletingContent += DeletingContent;
-
-            siteDefinitionEvents.SiteCreated += SiteChanged;
-            siteDefinitionEvents.SiteUpdated += SiteChanged;
-
-            initialized = true;
+            return;
         }
 
-        /// <summary>
-        /// Resets the module into an uninitialized state.
-        /// </summary>
-        /// <param name="context">The context.</param>
-        /// <remarks><para>
-        /// This method is usually not called when running under a web application since the web app may be shut down very
-        /// abruptly, but your module should still implement it properly since it will make integration and unit testing
-        /// much simpler.
-        /// </para>
-        /// <para>
-        /// Any work done by <see cref="M:EPiServer.Framework.IInitializableModule.Initialize(EPiServer.Framework.Initialization.InitializationEngine)" /> as well as any code executing on <see cref="E:EPiServer.Framework.Initialization.InitializationEngine.InitComplete" /> should be reversed.
-        /// </para></remarks>
-        public void Uninitialize(InitializationEngine context)
+        if (initialized)
         {
-            if (context == null)
-            {
-                return;
-            }
-
-            if (!initialized)
-            {
-                return;
-            }
-
-            contentEvents.PublishedContent -= PublishedContent;
-            contentEvents.MovingContent -= MovingContent;
-            contentEvents.DeletingContent -= DeletingContent;
-            
-            siteDefinitionEvents.SiteCreated -= SiteChanged;
-            siteDefinitionEvents.SiteUpdated -= SiteChanged;
-
-            initialized = false;
+            return;
         }
 
-        /// <summary>
-        /// Executed when the content is being deleted.
-        /// </summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="e">The <see cref="DeleteContentEventArgs"/> instance containing the event data.</param>
-        private static void DeletingContent(object sender, DeleteContentEventArgs e)
+        context.InitComplete += (sender, args) =>
         {
-            if (e == null || e.Content == null)
+            var moduleTable = context.Locate.Advanced.GetInstance<ModuleTable>();
+            var modules = moduleTable.GetModules().ToList();
+            var settings = modules.FirstOrDefault(m => string.Equals(m.Name, "AddOn.Episerver.Settings", StringComparison.OrdinalIgnoreCase));
+            var commerce = modules.FirstOrDefault(m => string.Equals(m.Name, "EPiServer.Commerce.Shell", StringComparison.OrdinalIgnoreCase));
+
+            if (settings != null && commerce != null)
             {
-                return;
+                settings.Manifest.ClientModule.ModuleDependencies.Add(new ModuleDependency
+                    { Dependency = "EPiServer.Commerce.Shell", DependencyType = ModuleDependencyTypes.Require | ModuleDependencyTypes.RunAfter });
             }
+        };
 
-            // if the content item is an instance of SettingsBase, it has been instantiated with the fallback base class
-            // since the ContentType class no longer exists and should be possible to delete
-            if (e.Content.GetOriginalType() == typeof(SettingsBase)  || !(e.Content is SettingsBase) || e.Content.ParentLink != settingsService.GlobalSettingsRoot)
-            {
-                return;
-            }
+        settingsService = context.Locate.Advanced.GetInstance<ISettingsService>();
+        contentEvents = context.Locate.Advanced.GetInstance<IContentEvents>();
+        siteDefinitionEvents = context.Locate.Advanced.GetInstance<ISiteDefinitionEvents>();
+        localizationService = context.Locate.Advanced.GetInstance<LocalizationService>();
 
-            e.CancelAction = true;
-            e.CancelReason = localizationService.GetString("/edit/deletesetting/deletenotsupported");
-        }
+        context.InitComplete += InitCompleteHandler;
 
-        /// <summary>
-        /// Initializes the complete handler.
-        /// </summary>
-        /// <param name="sender"> The sender. </param>
-        /// <param name="e"> The <see cref="EventArgs"/> instance containing the event data. </param>
-        /// <exception cref="T:System.NotSupportedException">If the rootname is already registered with another contentRootId.</exception>
-        private static void InitCompleteHandler(object sender, EventArgs e)
+        contentEvents.PublishedContent += PublishedContent;
+        contentEvents.MovingContent += MovingContent;
+        contentEvents.DeletingContent += DeletingContent;
+
+        siteDefinitionEvents.SiteCreated += SiteChanged;
+        siteDefinitionEvents.SiteUpdated += SiteChanged;
+
+        initialized = true;
+    }
+
+    /// <summary>
+    ///     Resets the module into an uninitialized state.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    /// <remarks>
+    ///     <para>
+    ///         This method is usually not called when running under a web application since the web app may be shut down very
+    ///         abruptly, but your module should still implement it properly since it will make integration and unit testing
+    ///         much simpler.
+    ///     </para>
+    ///     <para>
+    ///         Any work done by
+    ///         <see
+    ///             cref="M:EPiServer.Framework.IInitializableModule.Initialize(EPiServer.Framework.Initialization.InitializationEngine)" />
+    ///         as well as any code executing on
+    ///         <see cref="E:EPiServer.Framework.Initialization.InitializationEngine.InitComplete" /> should be reversed.
+    ///     </para>
+    /// </remarks>
+    public void Uninitialize(InitializationEngine context)
+    {
+        if (context == null)
         {
-            settingsService.InitSettings();
+            return;
         }
 
-        /// <summary>
-        /// Executed when the content is being moved.
-        /// </summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="e">The <see cref="ContentEventArgs"/> instance containing the event data.</param>
-        private static void MovingContent(object sender, ContentEventArgs e)
+        if (!initialized)
         {
-            if (e == null)
-            {
-                return;
-            }
-
-            // if the content item is an instance of SettingsBase, it has been instantiated with the fallback base class
-            // since the ContentType class no longer exists and should be possible to move to the waste basket
-            if (e.Content.GetOriginalType() == typeof(SettingsBase) || !(e.Content is SettingsBase) || e.Content.ParentLink != settingsService.GlobalSettingsRoot
-                || e.TargetLink.ID != 2)
-            {
-                return;
-            }
-
-            e.CancelAction = true;
-            e.CancelReason = localizationService.GetString("/edit/deletesetting/deletenotsupported");
+            return;
         }
 
-        /// <summary>
-        /// Executed when the content is published.
-        /// </summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="e">The <see cref="ContentEventArgs"/> instance containing the event data.</param>
-        private static void PublishedContent(object sender, ContentEventArgs e)
+        contentEvents.PublishedContent -= PublishedContent;
+        contentEvents.MovingContent -= MovingContent;
+        contentEvents.DeletingContent -= DeletingContent;
+
+        siteDefinitionEvents.SiteCreated -= SiteChanged;
+        siteDefinitionEvents.SiteUpdated -= SiteChanged;
+
+        initialized = false;
+    }
+
+    /// <summary>
+    ///     Executed when the content is being deleted.
+    /// </summary>
+    /// <param name="sender">The sender.</param>
+    /// <param name="e">The <see cref="DeleteContentEventArgs" /> instance containing the event data.</param>
+    private static void DeletingContent(object sender, DeleteContentEventArgs e)
+    {
+        if (e == null || e.Content == null)
         {
-            if (e == null)
-            {
-                return;
-            }
+            return;
+        }
 
-            settingsService.UpdateSettings(e.Content);
-        }
-        
-        public static void SiteChanged(object sender, SiteDefinitionEventArgs e)
+        // if the content item is an instance of SettingsBase, it has been instantiated with the fallback base class
+        // since the ContentType class no longer exists and should be possible to delete
+        if (e.Content.GetOriginalType() == typeof(SettingsBase) || !(e.Content is SettingsBase) || e.Content.ParentLink != settingsService.GlobalSettingsRoot)
         {
-            if (e.Site == null)
-            {
-                return;
-            }
-            
-            settingsService.ValidateOrCreateSiteSettingsRoot(e.Site);
+            return;
         }
+
+        e.CancelAction = true;
+        e.CancelReason = localizationService.GetString("/edit/deletesetting/deletenotsupported");
+    }
+
+    /// <summary>
+    ///     Initializes the complete handler.
+    /// </summary>
+    /// <param name="sender"> The sender. </param>
+    /// <param name="e"> The <see cref="EventArgs" /> instance containing the event data. </param>
+    /// <exception cref="T:System.NotSupportedException">If the rootname is already registered with another contentRootId.</exception>
+    private static void InitCompleteHandler(object sender, EventArgs e)
+    {
+        settingsService.InitSettings();
+    }
+
+    /// <summary>
+    ///     Executed when the content is being moved.
+    /// </summary>
+    /// <param name="sender">The sender.</param>
+    /// <param name="e">The <see cref="ContentEventArgs" /> instance containing the event data.</param>
+    private static void MovingContent(object sender, ContentEventArgs e)
+    {
+        if (e == null)
+        {
+            return;
+        }
+
+        // if the content item is an instance of SettingsBase, it has been instantiated with the fallback base class
+        // since the ContentType class no longer exists and should be possible to move to the waste basket
+        if (e.Content.GetOriginalType() == typeof(SettingsBase) ||
+            !(e.Content is SettingsBase) ||
+            e.Content.ParentLink != settingsService.GlobalSettingsRoot ||
+            e.TargetLink.ID != 2)
+        {
+            return;
+        }
+
+        e.CancelAction = true;
+        e.CancelReason = localizationService.GetString("/edit/deletesetting/deletenotsupported");
+    }
+
+    /// <summary>
+    ///     Executed when the content is published.
+    /// </summary>
+    /// <param name="sender">The sender.</param>
+    /// <param name="e">The <see cref="ContentEventArgs" /> instance containing the event data.</param>
+    private static void PublishedContent(object sender, ContentEventArgs e)
+    {
+        if (e == null)
+        {
+            return;
+        }
+
+        settingsService.UpdateSettings(e.Content);
+    }
+
+    public static void SiteChanged(object sender, SiteDefinitionEventArgs e)
+    {
+        if (e.Site == null)
+        {
+            return;
+        }
+
+        settingsService.ValidateOrCreateSiteSettingsRoot(e.Site);
     }
 }

--- a/src/AddOn.Episerver.Settings/Core/SettingsService.cs
+++ b/src/AddOn.Episerver.Settings/Core/SettingsService.cs
@@ -21,494 +21,528 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
+using EPiServer;
+using EPiServer.Core;
+using EPiServer.DataAbstraction;
 using EPiServer.DataAccess;
+using EPiServer.Framework.Cache;
+using EPiServer.Framework.TypeScanner;
+using EPiServer.Logging;
 using EPiServer.Security;
+using EPiServer.Web;
+using EPiServer.Web.Routing;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 
-namespace AddOn.Episerver.Settings.Core
+namespace AddOn.Episerver.Settings.Core;
+
+/// <summary>
+///     Class SettingsService.
+///     Implements the <see cref="ISettingsService" />
+/// </summary>
+/// <seealso cref="ISettingsService" />
+public class SettingsService : ISettingsService
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Collections.Concurrent;
-
-    using EPiServer;
-    using EPiServer.Core;
-    using EPiServer.DataAbstraction;
-    using EPiServer.Framework.Cache;
-    using EPiServer.Framework.TypeScanner;
-    using EPiServer.Logging;
-    using EPiServer.Web;
-    using EPiServer.Web.Routing;
+    /// <summary>
+    ///     The global settings root name
+    /// </summary>
+    public const string GlobalSettingsRootName = "Global Settings Root";
 
     /// <summary>
-    /// Class SettingsService.
-    /// Implements the <see cref="ISettingsService" />
+    ///     The settings root name
     /// </summary>
-    /// <seealso cref="ISettingsService" />
-    public class SettingsService : ISettingsService
+    public const string SettingsRootName = "Settings Root";
+
+    /// <summary>
+    ///     The site settings root name
+    /// </summary>
+    public const string SiteSettingsRootName = "Site Settings Root";
+
+    /// <summary>
+    ///     The ancestor references loader
+    /// </summary>
+    private readonly AncestorReferencesLoader ancestorReferencesLoader;
+
+    /// <summary>
+    ///     The synchronized object instance cache
+    /// </summary>
+    private readonly ISynchronizedObjectInstanceCache cache;
+
+    /// <summary>
+    ///     The content repository
+    /// </summary>
+    private readonly IContentRepository contentRepository;
+
+    /// <summary>
+    ///     The content root service
+    /// </summary>
+    private readonly ContentRootService contentRootService;
+
+    /// <summary>
+    ///     The content type repository
+    /// </summary>
+    private readonly IContentTypeRepository contentTypeRepository;
+
+    /// <summary>
+    ///     The key used for storing global settings in the synchronized cache
+    /// </summary>
+    private readonly string globalSettingsCacheKey = "addon.episerver.settings.globalsettings";
+
+    /// <summary>
+    ///     The logger instance
+    /// </summary>
+    private readonly ILogger log = LogManager.GetLogger();
+
+    /// <summary>
+    ///     The site definition repository
+    /// </summary>
+    private readonly ISiteDefinitionRepository siteDefinitionRepository;
+
+    private readonly ConcurrentDictionary<Guid, ContentReference> siteSettingsRoots = new ConcurrentDictionary<Guid, ContentReference>();
+
+    /// <summary>
+    ///     The type scanner lookup
+    /// </summary>
+    private readonly ITypeScannerLookup typeScannerLookup;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="SettingsService" /> class.
+    /// </summary>
+    /// <param name="contentRepository">The content repository.</param>
+    /// <param name="siteDefinitionRepository">The site definition reposi</param>
+    /// <param name="contentRootService">The content root service.</param>
+    /// <param name="typeScannerLookup">The type scanner lookup.</param>
+    /// <param name="contentTypeRepository">The content type repository.</param>
+    /// <param name="ancestorReferencesLoader">The ancestor references loader.</param>
+    /// <param name="synchronizedObjectInstanceCache"></param>
+    public SettingsService(
+        IContentRepository contentRepository,
+        ISiteDefinitionRepository siteDefinitionRepository,
+        ContentRootService contentRootService,
+        ITypeScannerLookup typeScannerLookup,
+        IContentTypeRepository contentTypeRepository,
+        AncestorReferencesLoader ancestorReferencesLoader,
+        ISynchronizedObjectInstanceCache synchronizedObjectInstanceCache)
     {
-        /// <summary>
-        /// The global settings root name
-        /// </summary>
-        public const string GlobalSettingsRootName = "Global Settings Root";
+        this.contentRepository = contentRepository;
+        this.siteDefinitionRepository = siteDefinitionRepository;
+        this.contentRootService = contentRootService;
+        this.typeScannerLookup = typeScannerLookup;
+        this.contentTypeRepository = contentTypeRepository;
+        this.ancestorReferencesLoader = ancestorReferencesLoader;
+        cache = synchronizedObjectInstanceCache;
+    }
 
-        /// <summary>
-        /// The settings root name
-        /// </summary>
-        public const string SettingsRootName = "Settings Root";
-        
-        /// <summary>
-        /// The site settings root name
-        /// </summary>
-        public const string SiteSettingsRootName = "Site Settings Root";
+    /// <summary>
+    ///     Gets the global settings root unique identifier
+    /// </summary>
+    private Guid GlobalSettingsRootGuid { get; } = new Guid("98ed413d-d7b5-4fbf-92a6-120d850fe61a");
 
-        /// <summary>
-        /// The key used for storing global settings in the synchronized cache
-        /// </summary>
-        private readonly string globalSettingsCacheKey = "addon.episerver.settings.globalsettings";
+    /// <summary>
+    ///     Gets the settings root unique identifier
+    /// </summary>
+    private Guid SettingsRootGuid { get; } = new Guid("98ed413d-d7b5-4fbf-92a6-120d850fe61c");
 
-        /// <summary>
-        /// The ancestor references loader
-        /// </summary>
-        private readonly AncestorReferencesLoader ancestorReferencesLoader;
+    /// <summary>
+    ///     Gets the global settings.
+    /// </summary>
+    /// <value>The global settings.</value>
+    public Dictionary<Type, ContentReference> GlobalSettings => GetGlobalSettings();
 
-        /// <summary>
-        /// The content repository
-        /// </summary>
-        private readonly IContentRepository contentRepository;
+    /// <summary>
+    ///     Gets or sets the global settings root.
+    /// </summary>
+    /// <value>The global settings root.</value>
+    public ContentReference GlobalSettingsRoot { get; set; }
 
-        /// <summary>
-        /// The site definition repository
-        /// </summary>
-        private readonly ISiteDefinitionRepository siteDefinitionRepository;
+    /// <summary>
+    ///     Gets or sets the settings root.
+    /// </summary>
+    /// <value>The settings root.</value>
+    public ContentReference SettingsRoot { get; set; }
 
-        /// <summary>
-        /// The content root service
-        /// </summary>
-        private readonly ContentRootService contentRootService;
-
-        /// <summary>
-        /// The content type repository
-        /// </summary>
-        private readonly IContentTypeRepository contentTypeRepository;
-
-        /// <summary>
-        /// The logger instance
-        /// </summary>
-        private readonly ILogger log = LogManager.GetLogger();
-
-        /// <summary>
-        /// The type scanner lookup
-        /// </summary>
-        private readonly ITypeScannerLookup typeScannerLookup;
-
-        /// <summary>
-        /// The synchronized object instance cache
-        /// </summary>
-        private readonly ISynchronizedObjectInstanceCache cache;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SettingsService"/> class.
-        /// </summary>
-        /// <param name="contentRepository">The content repository.</param>
-        /// <param name="siteDefinitionRepository">The site definition reposi</param>
-        /// <param name="contentRootService">The content root service.</param>
-        /// <param name="typeScannerLookup">The type scanner lookup.</param>
-        /// <param name="contentTypeRepository">The content type repository.</param>
-        /// <param name="ancestorReferencesLoader">The ancestor references loader.</param>
-        /// <param name="synchronizedObjectInstanceCache"></param>
-        public SettingsService(
-            IContentRepository contentRepository,
-            ISiteDefinitionRepository siteDefinitionRepository,
-            ContentRootService contentRootService,
-            ITypeScannerLookup typeScannerLookup,
-            IContentTypeRepository contentTypeRepository,
-            AncestorReferencesLoader ancestorReferencesLoader,
-            ISynchronizedObjectInstanceCache synchronizedObjectInstanceCache)
+    /// <summary>
+    ///     Gets the settings roots. In case site-specific assets are enabled this will contain
+    ///     both the shared and site specific roots, otherwise only the shared root.
+    /// </summary>
+    /// <value>The settings root.</value>
+    public IEnumerable<ContentReference> SettingsRoots
+    {
+        get
         {
-            this.contentRepository = contentRepository;
-            this.siteDefinitionRepository = siteDefinitionRepository;
-            this.contentRootService = contentRootService;
-            this.typeScannerLookup = typeScannerLookup;
-            this.contentTypeRepository = contentTypeRepository;
-            this.ancestorReferencesLoader = ancestorReferencesLoader;
-            this.cache = synchronizedObjectInstanceCache;
-        }
-
-        /// <summary>
-        /// Gets the global settings.
-        /// </summary>
-        /// <value>The global settings.</value>
-        public Dictionary<Type, ContentReference> GlobalSettings => this.GetGlobalSettings();
-
-        /// <summary>
-        /// Gets or sets the global settings root.
-        /// </summary>
-        /// <value>The global settings root.</value>
-        public ContentReference GlobalSettingsRoot { get; set; }
-        
-        /// <summary>
-        /// Gets or sets the settings root.
-        /// </summary>
-        /// <value>The settings root.</value>
-        public ContentReference SettingsRoot { get; set; }
-        
-        /// <summary>
-        /// Gets the settings roots. In case site-specific assets are enabled this will contain
-        /// both the shared and site specific roots, otherwise only the shared root.
-        /// </summary>
-        /// <value>The settings root.</value>
-        public IEnumerable<ContentReference> SettingsRoots {
-            get
+            var settings = new List<ContentReference> { SettingsRoot };
+            if (!SiteDefinition.Current.GlobalAssetsRoot.CompareToIgnoreWorkID(SiteDefinition.Current.SiteAssetsRoot))
             {
-                var settings = new List<ContentReference> { SettingsRoot };
-                if (!SiteDefinition.Current.GlobalAssetsRoot.CompareToIgnoreWorkID(SiteDefinition.Current.SiteAssetsRoot))
+                if (siteSettingsRoots.TryGetValue(SiteDefinition.Current.Id, out var settingsRef))
                 {
-                    if (this.siteSettingsRoots.TryGetValue(SiteDefinition.Current.Id, out var settingsRef))
-                    {
-                        settings.Add(settingsRef);
-                    }
-                }
-
-                return settings;
-            }
-        }
-
-        private readonly ConcurrentDictionary<Guid, ContentReference> siteSettingsRoots = new ConcurrentDictionary<Guid, ContentReference>(); 
-
-        /// <summary>
-        /// Gets the global settings root unique identifier
-        /// </summary>
-        private Guid GlobalSettingsRootGuid { get; } = new Guid("98ed413d-d7b5-4fbf-92a6-120d850fe61a");
-
-        /// <summary>
-        /// Gets the settings root unique identifier
-        /// </summary>
-        private Guid SettingsRootGuid { get; } = new Guid("98ed413d-d7b5-4fbf-92a6-120d850fe61c");
-
-        /// <summary>
-        /// Gets the settings.
-        /// </summary>
-        /// <typeparam name="T">The settings type</typeparam>
-        /// <returns>An instance of <typeparamref name="T"/> </returns>
-        public T GetSettings<T>() where T : IContent
-        {
-            try
-            {
-                var type = typeof(T);
-                var globalSettings = GetGlobalSettings();
-
-                if (globalSettings.ContainsKey(type))
-                {
-                    return contentRepository.Get<T>(globalSettings[type]);
+                    settings.Add(settingsRef);
                 }
             }
-            catch (KeyNotFoundException keyNotFoundException)
-            {
-                this.log.Error($"[Settings] {keyNotFoundException.Message}", exception: keyNotFoundException);
-            }
-            catch (ArgumentNullException argumentNullException)
-            {
-                this.log.Error($"[Settings] {argumentNullException.Message}", exception: argumentNullException);
-            }
 
-            return default(T);
+            return settings;
+        }
+    }
+
+    /// <summary>
+    ///     Gets the settings.
+    /// </summary>
+    /// <typeparam name="T">The settings type</typeparam>
+    /// <returns>An instance of <typeparamref name="T" /> </returns>
+    public T GetSettings<T>() where T : IContent
+    {
+        try
+        {
+            var type = typeof(T);
+            var globalSettings = GetGlobalSettings();
+
+            if (globalSettings.ContainsKey(type))
+            {
+                return contentRepository.Get<T>(globalSettings[type]);
+            }
+        }
+        catch (KeyNotFoundException keyNotFoundException)
+        {
+            log.Error($"[Settings] {keyNotFoundException.Message}", keyNotFoundException);
+        }
+        catch (ArgumentNullException argumentNullException)
+        {
+            log.Error($"[Settings] {argumentNullException.Message}", argumentNullException);
         }
 
-        /// <summary>
-        /// Gets the settings.
-        /// </summary>
-        /// <typeparam name="T">The settings type</typeparam>
-        /// <param name="content">The content.</param>
-        /// <returns>An instance of <typeparamref name="T"/> </returns>
-        /// <exception cref="T:System.Threading.SynchronizationLockException">The current thread has not entered the lock in read mode.</exception>
-        /// <exception cref="T:System.Threading.LockRecursionException">The current thread cannot acquire the write lock when it holds the read lock.-or-The <see cref="P:System.Threading.ReaderWriterLockSlim.RecursionPolicy" /> property is <see cref="F:System.Threading.LockRecursionPolicy.NoRecursion" />, and the current thread has attempted to acquire the read lock when it already holds the read lock. -or-The <see cref="P:System.Threading.ReaderWriterLockSlim.RecursionPolicy" /> property is <see cref="F:System.Threading.LockRecursionPolicy.NoRecursion" />, and the current thread has attempted to acquire the read lock when it already holds the write lock. -or-The recursion number would exceed the capacity of the counter. This limit is so large that applications should never encounter this exception.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Threading.ReaderWriterLockSlim" /> object has been disposed.</exception>
-        public T GetSettings<T>(IContent content)
-            where T : IContent
+        return default;
+    }
+
+    /// <summary>
+    ///     Gets the settings.
+    /// </summary>
+    /// <typeparam name="T">The settings type</typeparam>
+    /// <param name="content">The content.</param>
+    /// <returns>An instance of <typeparamref name="T" /> </returns>
+    /// <exception cref="T:System.Threading.SynchronizationLockException">
+    ///     The current thread has not entered the lock in read
+    ///     mode.
+    /// </exception>
+    /// <exception cref="T:System.Threading.LockRecursionException">
+    ///     The current thread cannot acquire the write lock when it
+    ///     holds the read lock.-or-The <see cref="P:System.Threading.ReaderWriterLockSlim.RecursionPolicy" /> property is
+    ///     <see cref="F:System.Threading.LockRecursionPolicy.NoRecursion" />, and the current thread has attempted to acquire
+    ///     the read lock when it already holds the read lock. -or-The
+    ///     <see cref="P:System.Threading.ReaderWriterLockSlim.RecursionPolicy" /> property is
+    ///     <see cref="F:System.Threading.LockRecursionPolicy.NoRecursion" />, and the current thread has attempted to acquire
+    ///     the read lock when it already holds the write lock. -or-The recursion number would exceed the capacity of the
+    ///     counter. This limit is so large that applications should never encounter this exception.
+    /// </exception>
+    /// <exception cref="T:System.ObjectDisposedException">
+    ///     The <see cref="T:System.Threading.ReaderWriterLockSlim" /> object
+    ///     has been disposed.
+    /// </exception>
+    public T GetSettings<T>(IContent content)
+        where T : IContent
+    {
+        if (content == null)
         {
-            if (content == null)
+            return default;
+        }
+
+        var settingsFromContent = TryGetSettingsFromContent<T>(content);
+
+        if (settingsFromContent != null)
+        {
+            return settingsFromContent;
+        }
+
+        var ancestors =
+            ancestorReferencesLoader.GetAncestors(content.ContentLink);
+
+        foreach (var parentReference in ancestors)
+        {
+            IContent parentContent;
+
+            if (!contentRepository.TryGet(parentReference, out parentContent))
             {
-                return default;
+                continue;
             }
 
-            T settingsFromContent = this.TryGetSettingsFromContent<T>(content: content);
+            settingsFromContent = TryGetSettingsFromContent<T>(parentContent);
 
             if (settingsFromContent != null)
             {
                 return settingsFromContent;
             }
-
-            IEnumerable<ContentReference> ancestors =
-                this.ancestorReferencesLoader.GetAncestors(contentLink: content.ContentLink);
-
-            foreach (ContentReference parentReference in ancestors)
-            {
-                IContent parentContent;
-
-                if (!this.contentRepository.TryGet(contentLink: parentReference, content: out parentContent))
-                {
-                    continue;
-                }
-
-                settingsFromContent = this.TryGetSettingsFromContent<T>(content: parentContent);
-
-                if (settingsFromContent != null)
-                {
-                    return settingsFromContent;
-                }
-            }
-
-            return this.GetSettings<T>();
         }
 
-        /// <summary>
-        /// Initializes the settings.
-        /// </summary>
-        /// <exception cref="T:System.NotSupportedException">If the rootname is already registered with another contentRootId.</exception>
-        public void InitSettings()
+        return GetSettings<T>();
+    }
+
+    /// <summary>
+    ///     Initializes the settings.
+    /// </summary>
+    /// <exception cref="T:System.NotSupportedException">If the rootname is already registered with another contentRootId.</exception>
+    public void InitSettings()
+    {
+        try
         {
+            contentRootService.Register<ContentFolder>(
+            GlobalSettingsRootName,
+            GlobalSettingsRootGuid,
+            SiteDefinition.Current.GlobalAssetsRoot);
+
+            GlobalSettingsRoot = contentRootService.Get(GlobalSettingsRootName);
+        }
+        catch (NotSupportedException notSupportedException)
+        {
+            log.Error($"[Settings] {notSupportedException.Message}", notSupportedException);
+            throw;
+        }
+
+        try
+        {
+            contentRootService.Register<ContentFolder>(
+            SettingsRootName,
+            SettingsRootGuid,
+            SiteDefinition.Current.SiteAssetsRoot);
+
+            SettingsRoot = contentRootService.Get(SettingsRootName);
+        }
+        catch (NotSupportedException notSupportedException)
+        {
+            log.Error($"[Settings] {notSupportedException.Message}", notSupportedException);
+            throw;
+        }
+
+        foreach (var siteDefinition in siteDefinitionRepository.List())
+        {
+            ValidateOrCreateSiteSettingsRoot(siteDefinition);
+        }
+
+        InitializeContentInstances();
+    }
+
+    /// <summary>
+    ///     Updates the settings.
+    /// </summary>
+    /// <param name="content">The content.</param>
+    /// <exception cref="T:System.Threading.LockRecursionException">
+    ///     The
+    ///     <see cref="P:System.Threading.ReaderWriterLockSlim.RecursionPolicy" /> property is
+    ///     <see cref="F:System.Threading.LockRecursionPolicy.NoRecursion" /> and the current thread has already entered the
+    ///     lock in any mode. -or-The current thread has entered read mode, so trying to enter the lock in write mode would
+    ///     create the possibility of a deadlock. -or-The recursion number would exceed the capacity of the counter. The limit
+    ///     is so large that applications should never encounter it.
+    /// </exception>
+    /// <exception cref="T:System.ObjectDisposedException">
+    ///     The <see cref="T:System.Threading.ReaderWriterLockSlim" /> object
+    ///     has been disposed.
+    /// </exception>
+    /// <exception cref="T:System.Threading.SynchronizationLockException">
+    ///     The current thread has not entered the lock in write
+    ///     mode.
+    /// </exception>
+    public void UpdateSettings(IContent content)
+    {
+        try
+        {
+            if (content is SettingsBase && content.ParentLink == GlobalSettingsRoot)
+            {
+                ClearCache();
+            }
+        }
+        catch (EPiServerException ePiServerException)
+        {
+            log.Error($"[Settings] {ePiServerException.Message}", ePiServerException);
+        }
+    }
+
+    /// <summary>
+    ///     Creates a settings folder for a site and adds it to the settings lookup
+    /// </summary>
+    public ContentReference ValidateOrCreateSiteSettingsRoot(SiteDefinition siteDefinition)
+    {
+        if (siteDefinition.SiteAssetsRoot.CompareToIgnoreWorkID(siteDefinition.GlobalAssetsRoot))
+        {
+            return ContentReference.EmptyReference;
+        }
+
+        try
+        {
+            return siteSettingsRoots.GetOrAdd(siteDefinition.Id, id =>
+            {
+                var contentRootId = DeterministicGuid.Create(siteDefinition.Id, SettingsRootName);
+                if (!contentRepository.TryGet<ContentFolder>(contentRootId, out var root))
+                {
+                    root = contentRepository.GetDefault<ContentFolder>(siteDefinition.SiteAssetsRoot);
+                    root.ContentGuid = contentRootId;
+                    root.Name = SiteSettingsRootName;
+
+                    contentRepository.Save(root, SaveAction.Publish | SaveAction.SkipValidation, AccessLevel.NoAccess);
+                }
+
+                return root.ContentLink;
+            });
+        }
+        catch (NotSupportedException notSupportedException)
+        {
+            log.Error($"[Settings] {notSupportedException.Message}", notSupportedException);
+            throw;
+        }
+    }
+
+    /// <summary>
+    ///     Initializes the content instances.
+    /// </summary>
+    /// <exception cref="T:EPiServer.Core.EPiServerException">
+    ///     Could not create instance of a content type since it has an
+    ///     invalid .NET class associated. This happens if a class have been deleted, try remove the content type in Admin or
+    ///     from database."
+    /// </exception>
+    private void InitializeContentInstances()
+    {
+        var existingItems = new List<IContent>();
+        var type = typeof(SettingsContentTypeAttribute);
+        var settingsModelTypes = typeScannerLookup.AllTypes.Where(
+        t => t.GetCustomAttributes(type, false).Length > 0);
+
+        try
+        {
+            existingItems = LoadGlobalSettings().ToList();
+        }
+        catch (EPiServerException ePiServerException)
+        {
+            log.Error($"[Settings] {ePiServerException.Message}", ePiServerException);
+        }
+
+        foreach (var settingsType in settingsModelTypes)
+        {
+            var attribute =
+                settingsType.GetCustomAttributes(type, false).FirstOrDefault() as
+                    SettingsContentTypeAttribute;
+
+            if (attribute == null)
+            {
+                continue;
+            }
+
+            if (attribute.SettingsInstanceGuid == null)
+            {
+                var errorMessage =
+                    $"The SettingsInstanceGuid property must be set on the SettingsContentTypeAttribute of the Settings type {settingsType.Name}";
+
+                log.Error(errorMessage);
+                throw new ArgumentException(errorMessage);
+            }
+
+            var attributeGuid = new Guid(attribute.SettingsInstanceGuid);
+            IContent existingItem = null;
+
+            if (existingItems.Any())
+            {
+                existingItem = existingItems.FirstOrDefault(i => i.ContentGuid == attributeGuid);
+            }
+
+            if (existingItem == null)
+            {
+                contentRepository.TryGet(attributeGuid, out existingItem);
+            }
+
+            if (existingItem == null)
+            {
+                var contentType = contentTypeRepository.Load(settingsType);
+
+                var newSettings = contentRepository.GetDefault<IContent>(
+                GlobalSettingsRoot,
+                contentType.ID);
+
+                newSettings.Name = attribute.SettingsName;
+                newSettings.ContentGuid = new Guid(attribute.SettingsInstanceGuid);
+
+                contentRepository.Save(
+                newSettings,
+                SaveAction.Publish,
+                AccessLevel.NoAccess);
+            }
+        }
+
+        // In case any reads of global settings has occured while populating the settings
+        ClearCache();
+    }
+
+    /// <summary>
+    ///     Tries to get the settings from content.
+    /// </summary>
+    /// <typeparam name="T">The settings type</typeparam>
+    /// <param name="content">The content.</param>
+    /// <returns>An instance of <typeparamref name="T" /> </returns>
+    private T TryGetSettingsFromContent<T>(IContent content)
+        where T : IContent
+    {
+        var property = content.Property[typeof(T).Name];
+
+        if (property == null || property.IsNull)
+        {
+            return default;
+        }
+
+        var reference = property.Value as ContentReference;
+
+        if (reference == null)
+        {
+            return default;
+        }
+
+        T settingsObject;
+
+        contentRepository.TryGet(reference, out settingsObject);
+
+        return settingsObject != null ? settingsObject : default;
+    }
+
+    /// <summary>Loads the global settings instances from below the Global settings root.</summary>
+    /// <returns>
+    ///     All loadable children
+    /// </returns>
+    private IEnumerable<IContent> LoadGlobalSettings()
+    {
+        var existingItemRefs = contentRepository.GetDescendents(GlobalSettingsRoot);
+
+        foreach (var itemRef in existingItemRefs)
+        {
+            IContent item = null;
+
             try
             {
-                this.contentRootService.Register<ContentFolder>(
-                    rootName: GlobalSettingsRootName,
-                    contentRootId: this.GlobalSettingsRootGuid,
-                    parent: SiteDefinition.Current.GlobalAssetsRoot);
-                this.GlobalSettingsRoot = this.contentRootService.Get(rootName: GlobalSettingsRootName);
+                item = contentRepository.Get<IContent>(itemRef);
             }
-            catch (NotSupportedException notSupportedException)
+            catch (EPiServerException ex)
             {
-                this.log.Error($"[Settings] {notSupportedException.Message}", exception: notSupportedException);
-                throw;
-            }
-            
-            try
-            {
-                this.contentRootService.Register<ContentFolder>(
-                    rootName: SettingsRootName,
-                    contentRootId: this.SettingsRootGuid,
-                    parent: SiteDefinition.Current.SiteAssetsRoot);
-                this.SettingsRoot = this.contentRootService.Get(rootName: SettingsRootName);
-            }
-            catch (NotSupportedException notSupportedException)
-            {
-                this.log.Error($"[Settings] {notSupportedException.Message}", exception: notSupportedException);
-                throw;
+                log.Error($"[Settings] {ex.Message}", ex);
             }
 
-            foreach (var siteDefinition in siteDefinitionRepository.List())
+            // If the item is an instance of SettingsBase has been loaded as a fallback 
+            // because the ContentType class no longer exists
+            if (item != null && item.GetOriginalType() != typeof(SettingsBase))
             {
-                this.ValidateOrCreateSiteSettingsRoot(siteDefinition);
-            }
-            
-            this.InitializeContentInstances();
-        }
-
-        /// <summary>
-        /// Updates the settings.
-        /// </summary>
-        /// <param name="content">The content.</param>
-        /// <exception cref="T:System.Threading.LockRecursionException">The <see cref="P:System.Threading.ReaderWriterLockSlim.RecursionPolicy" /> property is <see cref="F:System.Threading.LockRecursionPolicy.NoRecursion" /> and the current thread has already entered the lock in any mode. -or-The current thread has entered read mode, so trying to enter the lock in write mode would create the possibility of a deadlock. -or-The recursion number would exceed the capacity of the counter. The limit is so large that applications should never encounter it.</exception>
-        /// <exception cref="T:System.ObjectDisposedException">The <see cref="T:System.Threading.ReaderWriterLockSlim" /> object has been disposed.</exception>
-        /// <exception cref="T:System.Threading.SynchronizationLockException">The current thread has not entered the lock in write mode.</exception>
-        public void UpdateSettings(IContent content)
-        {
-            try
-            {
-                if (content is SettingsBase && content.ParentLink == this.GlobalSettingsRoot)
-                {
-                    this.ClearCache();
-                }
-            }
-            catch (EPiServerException ePiServerException)
-            {
-                this.log.Error($"[Settings] {ePiServerException.Message}", exception: ePiServerException);
+                yield return item;
             }
         }
+    }
 
-        /// <summary>
-        /// Creates a settings folder for a site and adds it to the settings lookup
-        /// </summary>
-        public ContentReference ValidateOrCreateSiteSettingsRoot(SiteDefinition siteDefinition)
-        {
-            if (siteDefinition.SiteAssetsRoot.CompareToIgnoreWorkID(siteDefinition.GlobalAssetsRoot))
-            {
-                return ContentReference.EmptyReference;
-            }
-            
-            try
-            {
-                return this.siteSettingsRoots.GetOrAdd(siteDefinition.Id, id =>
-                {
-                    var contentRootId = DeterministicGuid.Create(siteDefinition.Id, SettingsRootName);
-                    if (!this.contentRepository.TryGet<ContentFolder>(contentRootId, out var root))
-                    {
-                        root = this.contentRepository.GetDefault<ContentFolder>(siteDefinition.SiteAssetsRoot);
-                        root.ContentGuid = contentRootId;
-                        root.Name = SiteSettingsRootName;
+    /// <summary>Gets the global settings from the cache if they exist, otherwise an empty Dictionary.</summary>
+    /// <returns>
+    ///     A dictionary of all existing global settings instances from the cache
+    /// </returns>
+    private Dictionary<Type, ContentReference> GetGlobalSettings()
+    {
+        return cache.ReadThrough(
+        globalSettingsCacheKey,
+        () => LoadGlobalSettings().ToDictionary(item => item.GetOriginalType(), item => item.ContentLink),
+        ReadStrategy.Wait);
+    }
 
-                        this.contentRepository.Save(root, SaveAction.Publish | SaveAction.SkipValidation, AccessLevel.NoAccess);
-                    }
-                    
-                    return root.ContentLink;
-                });
-            }
-            catch (NotSupportedException notSupportedException)
-            {
-                this.log.Error($"[Settings] {notSupportedException.Message}", exception: notSupportedException);
-                throw;
-            }
-        }
-
-        /// <summary>
-        /// Initializes the content instances.
-        /// </summary>
-        /// <exception cref="T:EPiServer.Core.EPiServerException">Could not create instance of a content type since it has an invalid .NET class associated. This happens if a class have been deleted, try remove the content type in Admin or from database."</exception>
-        private void InitializeContentInstances()
-        {
-            List<IContent> existingItems = new List<IContent>();
-            Type type = typeof(SettingsContentTypeAttribute);
-            IEnumerable<Type> settingsModelTypes = this.typeScannerLookup.AllTypes.Where(
-                t => t.GetCustomAttributes(type, false).Length > 0);
-
-            try
-            {
-                existingItems = this.LoadGlobalSettings().ToList();
-            }
-            catch (EPiServerException ePiServerException)
-            {
-                this.log.Error($"[Settings] {ePiServerException.Message}", exception: ePiServerException);
-            }
-
-            foreach (Type settingsType in settingsModelTypes)
-            {
-                SettingsContentTypeAttribute attribute =
-                    settingsType.GetCustomAttributes(attributeType: type, false).FirstOrDefault() as
-                        SettingsContentTypeAttribute;
-
-                if (attribute == null)
-                {
-                    continue;
-                }
-
-                if (attribute.SettingsInstanceGuid == null)
-                {
-                    var errorMessage =
-                        $"The SettingsInstanceGuid property must be set on the SettingsContentTypeAttribute of the Settings type {settingsType.Name}";
-                    this.log.Error(errorMessage);
-                    throw new ArgumentException(errorMessage);
-                }
-
-                Guid attributeGuid = new Guid(g: attribute.SettingsInstanceGuid);
-                IContent existingItem = null;
-
-                if (existingItems.Any())
-                {
-                    existingItem = existingItems.FirstOrDefault(i => i.ContentGuid == attributeGuid);
-                }
-                if (existingItem == null)
-                {
-                    contentRepository.TryGet<IContent>(attributeGuid, out existingItem);
-                }
-
-                if (existingItem == null)
-                {
-                    ContentType contentType = this.contentTypeRepository.Load(modelType: settingsType);
-
-                    IContent newSettings = this.contentRepository.GetDefault<IContent>(
-                        parentLink: this.GlobalSettingsRoot,
-                        contentTypeID: contentType.ID);
-
-                    newSettings.Name = attribute.SettingsName;
-                    newSettings.ContentGuid = new Guid(g: attribute.SettingsInstanceGuid);
-
-                    this.contentRepository.Save(
-                        content: newSettings,
-                        action: EPiServer.DataAccess.SaveAction.Publish,
-                        access: EPiServer.Security.AccessLevel.NoAccess);
-                }
-            }
-
-            // In case any reads of global settings has occured while populating the settings
-            this.ClearCache();
-        }
-
-        /// <summary>
-        /// Tries to get the settings from content.
-        /// </summary>
-        /// <typeparam name="T">The settings type</typeparam>
-        /// <param name="content">The content.</param>
-        /// <returns>An instance of <typeparamref name="T"/> </returns>
-        private T TryGetSettingsFromContent<T>(IContent content)
-            where T : IContent
-        {
-            PropertyData property = content.Property[name: typeof(T).Name];
-
-            if (property == null || property.IsNull)
-            {
-                return default;
-            }
-
-            ContentReference reference = property.Value as ContentReference;
-
-            if (reference == null)
-            {
-                return default;
-            }
-
-            T settingsObject;
-
-            this.contentRepository.TryGet(contentLink: reference, content: out settingsObject);
-
-            return settingsObject != null ? settingsObject : default;
-        }
-
-        /// <summary>Loads the global settings instances from below the Global settings root.</summary>
-        /// <returns>
-        ///   All loadable children
-        /// </returns>
-        private IEnumerable<IContent> LoadGlobalSettings()
-        {
-            var existingItemRefs = this.contentRepository.GetDescendents(GlobalSettingsRoot);
-
-            foreach (var itemRef in existingItemRefs)
-            {
-                IContent item = null;
-
-                try
-                {
-                    item = contentRepository.Get<IContent>(itemRef);
-                }
-                catch (EPiServerException ex)
-                {
-                    this.log.Error($"[Settings] {ex.Message}", exception: ex);
-                }
-
-                // If the item is an instance of SettingsBase has been loaded as a fallback 
-                // because the ContentType class no longer exists
-                if (item != null && item.GetOriginalType() != typeof(SettingsBase))
-                {
-                    yield return item;
-                }
-            }
-        }
-
-        /// <summary>Gets the global settings from the cache if they exist, otherwise an empty Dictionary.</summary>
-        /// <returns>
-        ///   A dictionary of all existing global settings instances from the cache
-        /// </returns>
-        private Dictionary<Type, ContentReference> GetGlobalSettings()
-        {
-            return this.cache.ReadThrough(
-                globalSettingsCacheKey,
-                () =>  this.LoadGlobalSettings().ToDictionary(item => item.GetOriginalType(), item => item.ContentLink), 
-                ReadStrategy.Wait);
-        }
-
-        /// <summary>Removes the global settings entry from the cache.</summary>
-        private void ClearCache()
-        {
-            this.cache.Remove(globalSettingsCacheKey);
-        }
+    /// <summary>Removes the global settings entry from the cache.</summary>
+    private void ClearCache()
+    {
+        cache.Remove(globalSettingsCacheKey);
     }
 }

--- a/src/AddOn.Episerver.Settings/UI/GlobalSettingsComponent.cs
+++ b/src/AddOn.Episerver.Settings/UI/GlobalSettingsComponent.cs
@@ -21,28 +21,27 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace AddOn.Episerver.Settings.UI
-{
-    using EPiServer.Shell.ViewComposition;
+using EPiServer.Shell.ViewComposition;
 
+namespace AddOn.Episerver.Settings.UI;
+
+/// <summary>
+///     Component that provides a tree based navigation for global settings.
+///     Implements the <see cref="ComponentDefinitionBase" />
+/// </summary>
+/// <seealso cref="ComponentDefinitionBase" />
+[Component]
+public sealed class GlobalSettingsComponent : ComponentDefinitionBase
+{
     /// <summary>
-    /// Component that provides a tree based navigation for global settings.
-    /// Implements the <see cref="ComponentDefinitionBase" />
+    ///     Initializes a new instance of the <see cref="GlobalSettingsComponent" /> class.
     /// </summary>
-    /// <seealso cref="ComponentDefinitionBase" />
-    [Component]
-    public sealed class GlobalSettingsComponent : ComponentDefinitionBase
+    public GlobalSettingsComponent()
+        : base("epi-cms/component/MainNavigationComponent")
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GlobalSettingsComponent"/> class.
-        /// </summary>
-        public GlobalSettingsComponent()
-            : base("epi-cms/component/MainNavigationComponent")
-        {
-            this.LanguagePath = "/episerver/cms/components/globalsettings";
-            this.Title = "Global settings";
-            this.SortOrder = 100;
-            this.Settings.Add(new Setting("repositoryKey", value: GlobalSettingsRepositoryDescriptor.RepositoryKey));
-        }
+        LanguagePath = "/episerver/cms/components/globalsettings";
+        Title = "Global settings";
+        SortOrder = 100;
+        Settings.Add(new Setting("repositoryKey", GlobalSettingsRepositoryDescriptor.RepositoryKey));
     }
 }

--- a/src/AddOn.Episerver.Settings/UI/GlobalSettingsRepositoryDescriptor.cs
+++ b/src/AddOn.Episerver.Settings/UI/GlobalSettingsRepositoryDescriptor.cs
@@ -21,186 +21,126 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace AddOn.Episerver.Settings.UI
+using AddOn.Episerver.Settings.Core;
+using EPiServer.Core;
+using EPiServer.Framework.Localization;
+using EPiServer.ServiceLocation;
+using EPiServer.Shell;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AddOn.Episerver.Settings.UI;
+
+/// <summary>
+///     Class GlobalSettingsRepositoryDescriptor.
+///     Implements the <see cref="ContentRepositoryDescriptorBase" />
+/// </summary>
+/// <seealso cref="ContentRepositoryDescriptorBase" />
+[ServiceConfiguration(typeof(IContentRepositoryDescriptor))]
+public class GlobalSettingsRepositoryDescriptor : ContentRepositoryDescriptorBase
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-
-    using AddOn.Episerver.Settings.Core;
-
-    using EPiServer.Core;
-    using EPiServer.Framework.Localization;
-    using EPiServer.ServiceLocation;
-    using EPiServer.Shell;
+    /// <summary>
+    ///     Gets the repository key.
+    /// </summary>
+    /// <value>The repository key.</value>
+    public static string RepositoryKey => "globalsettings";
 
     /// <summary>
-    /// Class GlobalSettingsRepositoryDescriptor.
-    /// Implements the <see cref="ContentRepositoryDescriptorBase" />
+    ///     Gets the contained types.
     /// </summary>
-    /// <seealso cref="ContentRepositoryDescriptorBase" />
-    [ServiceConfiguration(typeof(IContentRepositoryDescriptor))]
-    public class GlobalSettingsRepositoryDescriptor : ContentRepositoryDescriptorBase
+    /// <value>The contained types.</value>
+    public override IEnumerable<Type> ContainedTypes
     {
-        /// <summary>
-        /// Gets the repository key.
-        /// </summary>
-        /// <value>The repository key.</value>
-        public static string RepositoryKey
-        {
-            get
-            {
-                return "globalsettings";
-            }
-        }
-
-        /// <summary>
-        /// Gets the contained types.
-        /// </summary>
-        /// <value>The contained types.</value>
-        public override IEnumerable<Type> ContainedTypes
-        {
-            get
-            {
-                return new[] { typeof(SettingsBase) };
-            }
-        }
-
-        /// <summary>
-        /// Gets the creatable types.
-        /// </summary>
-        /// <value>The creatable types.</value>
-        /// <remarks>Disable creating items by editors.</remarks>
-        public override IEnumerable<Type> CreatableTypes
-        {
-            get
-            {
-                return new Type[0];
-            }
-        }
-
-        /// <summary>
-        /// Gets the custom navigation widget.
-        /// </summary>
-        /// <value>The custom navigation widget.</value>
-        public override string CustomNavigationWidget
-        {
-            get
-            {
-                return "epi-cms/component/ContentNavigationTree";
-            }
-        }
-
-        /// <summary>
-        /// Gets the custom select title.
-        /// </summary>
-        /// <value>The custom select title.</value>
-        public override string CustomSelectTitle
-        {
-            get
-            {
-                return LocalizationService.Current.GetString("/contentrepositories/globalsettings/customselecttitle");
-            }
-        }
-
-        /// <summary>
-        /// Gets the key.
-        /// </summary>
-        /// <value>The key.</value>
-        public override string Key
-        {
-            get
-            {
-                return RepositoryKey;
-            }
-        }
-
-        /// <summary>
-        /// Gets the main views.
-        /// </summary>
-        /// <value>The main views.</value>
-        public override IEnumerable<string> MainViews
-        {
-            get
-            {
-                return new string[1] { SettingsView.ViewName };
-            }
-        }
-
-        /// <summary>
-        /// Gets the name.
-        /// </summary>
-        /// <value>The name.</value>
-        public override string Name
-        {
-            get
-            {
-                return LocalizationService.Current.GetString("/contentrepositories/globalsettings/name");
-            }
-        }
-
-        /// <summary>
-        /// Gets the prevent copying for.
-        /// </summary>
-        /// <value>The prevent copying for.</value>
-        public override IEnumerable<string> PreventCopyingFor
-        {
-            get
-            {
-                return this.Settings.Service.GlobalSettings.Select(
-                    gs => gs.Value.ToString());
-            }
-        }
-
-        /// <summary>
-        /// Gets the prevent deletion for.
-        /// </summary>
-        /// <value>The prevent deletion for.</value>
-        public override IEnumerable<string> PreventDeletionFor
-        {
-            get
-            {
-                return this.Settings.Service.GlobalSettings.Select(
-                    gs => gs.Value.ToString());
-            }
-        }
-
-        /// <summary>
-        /// Gets the roots.
-        /// </summary>
-        /// <value>The roots.</value>
-        public override IEnumerable<ContentReference> Roots
-        {
-            get
-            {
-                return new[] { this.Settings.Service.GlobalSettingsRoot };
-            }
-        }
-
-        /// <summary>
-        /// Gets the search area.
-        /// </summary>
-        /// <value>The search area.</value>
-        public override string SearchArea
-        {
-            get
-            {
-                return GlobalSettingsSearchProvider.SearchArea;
-            }
-        }
-
-        /// <summary>
-        /// Gets the sort order.
-        /// </summary>
-        /// <value>The sort order.</value>
-        public override int SortOrder
-        {
-            get
-            {
-                return 1000;
-            }
-        }
-
-        private Injected<ISettingsService> Settings { get; set; }
+        get { return new[] { typeof(SettingsBase) }; }
     }
+
+    /// <summary>
+    ///     Gets the creatable types.
+    /// </summary>
+    /// <value>The creatable types.</value>
+    /// <remarks>Disable creating items by editors.</remarks>
+    public override IEnumerable<Type> CreatableTypes => new Type[0];
+
+    /// <summary>
+    ///     Gets the custom navigation widget.
+    /// </summary>
+    /// <value>The custom navigation widget.</value>
+    public override string CustomNavigationWidget => "epi-cms/component/ContentNavigationTree";
+
+    /// <summary>
+    ///     Gets the custom select title.
+    /// </summary>
+    /// <value>The custom select title.</value>
+    public override string CustomSelectTitle => LocalizationService.Current.GetString("/contentrepositories/globalsettings/customselecttitle");
+
+    /// <summary>
+    ///     Gets the key.
+    /// </summary>
+    /// <value>The key.</value>
+    public override string Key => RepositoryKey;
+
+    /// <summary>
+    ///     Gets the main views.
+    /// </summary>
+    /// <value>The main views.</value>
+    public override IEnumerable<string> MainViews
+    {
+        get { return new string[1] { SettingsView.ViewName }; }
+    }
+
+    /// <summary>
+    ///     Gets the name.
+    /// </summary>
+    /// <value>The name.</value>
+    public override string Name => LocalizationService.Current.GetString("/contentrepositories/globalsettings/name");
+
+    /// <summary>
+    ///     Gets the prevent copying for.
+    /// </summary>
+    /// <value>The prevent copying for.</value>
+    public override IEnumerable<string> PreventCopyingFor
+    {
+        get
+        {
+            return Settings.Service.GlobalSettings.Select(
+            gs => gs.Value.ToString());
+        }
+    }
+
+    /// <summary>
+    ///     Gets the prevent deletion for.
+    /// </summary>
+    /// <value>The prevent deletion for.</value>
+    public override IEnumerable<string> PreventDeletionFor
+    {
+        get
+        {
+            return Settings.Service.GlobalSettings.Select(
+            gs => gs.Value.ToString());
+        }
+    }
+
+    /// <summary>
+    ///     Gets the roots.
+    /// </summary>
+    /// <value>The roots.</value>
+    public override IEnumerable<ContentReference> Roots
+    {
+        get { return new[] { Settings.Service.GlobalSettingsRoot }; }
+    }
+
+    /// <summary>
+    ///     Gets the search area.
+    /// </summary>
+    /// <value>The search area.</value>
+    public override string SearchArea => GlobalSettingsSearchProvider.SearchArea;
+
+    /// <summary>
+    ///     Gets the sort order.
+    /// </summary>
+    /// <value>The sort order.</value>
+    public override int SortOrder => 1000;
+
+    private Injected<ISettingsService> Settings { get; set; }
 }

--- a/src/AddOn.Episerver.Settings/UI/GlobalSettingsVersionsComponent.cs
+++ b/src/AddOn.Episerver.Settings/UI/GlobalSettingsVersionsComponent.cs
@@ -1,14 +1,13 @@
 ﻿using EPiServer.Shell.ViewComposition;
 
-namespace AddOn.Episerver.Settings.UI
+namespace AddOn.Episerver.Settings.UI;
+
+internal class GlobalSettingsVersionsComponent : ComponentDefinitionBase
 {
-    internal class GlobalSettingsVersionsComponent : ComponentDefinitionBase
+    public GlobalSettingsVersionsComponent() : base("epi-cms/component/VersionsComponent")
     {
-        public GlobalSettingsVersionsComponent() : base("epi-cms/component/VersionsComponent")
-        {
-            LanguagePath = "/episerver/cms/components/versions";
-            Title = "Versions";
-            SortOrder = 100;
-        }
+        LanguagePath = "/episerver/cms/components/versions";
+        Title = "Versions";
+        SortOrder = 100;
     }
 }

--- a/src/AddOn.Episerver.Settings/UI/GlobalSharedBlocksComponent.cs
+++ b/src/AddOn.Episerver.Settings/UI/GlobalSharedBlocksComponent.cs
@@ -1,17 +1,16 @@
 ﻿using EPiServer.Cms.Shell.UI.UIDescriptors;
 using EPiServer.Shell.ViewComposition;
 
-namespace AddOn.Episerver.Settings.UI
+namespace AddOn.Episerver.Settings.UI;
+
+internal class GlobalSharedBlocksComponent : ComponentDefinitionBase
 {
-    internal class GlobalSharedBlocksComponent : ComponentDefinitionBase
+    public GlobalSharedBlocksComponent()
+        : base("epi-cms/component/SharedBlocks")
     {
-        public GlobalSharedBlocksComponent()
-            : base("epi-cms/component/SharedBlocks")
-        {
-            LanguagePath = "/episerver/cms/components/sharedblocks";
-            Title = "Blocks";
-            SortOrder = 90;
-            Settings.Add(new Setting("repositoryKey", BlockRepositoryDescriptor.RepositoryKey));
-        }
+        LanguagePath = "/episerver/cms/components/sharedblocks";
+        Title = "Blocks";
+        SortOrder = 90;
+        Settings.Add(new Setting("repositoryKey", BlockRepositoryDescriptor.RepositoryKey));
     }
 }

--- a/src/AddOn.Episerver.Settings/UI/SettingsBaseUIDescriptor.cs
+++ b/src/AddOn.Episerver.Settings/UI/SettingsBaseUIDescriptor.cs
@@ -21,32 +21,30 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace AddOn.Episerver.Settings.UI
+using AddOn.Episerver.Settings.Core;
+using EPiServer.Core;
+using EPiServer.Shell;
+
+namespace AddOn.Episerver.Settings.UI;
+
+/// <summary>
+///     Class SettingsBaseUIDescriptor.
+///     Implements the <see cref="UIDescriptor{SettingsBase}" />
+/// </summary>
+/// <seealso cref="UIDescriptor{SettingsBase}" />
+[UIDescriptorRegistration]
+public class SettingsBaseUIDescriptor : UIDescriptor<SettingsBase>
 {
-    using AddOn.Episerver.Settings.Core;
-
-    using EPiServer.Core;
-    using EPiServer.Shell;
-
     /// <summary>
-    /// Class SettingsBaseUIDescriptor.
-    /// Implements the <see cref="UIDescriptor{SettingsBase}" />
+    ///     Initializes a new instance of the <see cref="SettingsBaseUIDescriptor" /> class.
     /// </summary>
-    /// <seealso cref="UIDescriptor{SettingsBase}" />
-    [UIDescriptorRegistration]
-    public class SettingsBaseUIDescriptor : UIDescriptor<SettingsBase>
+    public SettingsBaseUIDescriptor()
+        : base("dijitIcon")
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SettingsBaseUIDescriptor" /> class.
-        /// </summary>
-        public SettingsBaseUIDescriptor()
-            : base("dijitIcon")
-        {
-            this.IsPrimaryType = true;
-            this.ContainerTypes = new[] { typeof(ContentFolder) };
-            this.CommandIconClass = "epi-iconSettings";
-            this.IconClass = "epi-iconSettings";
-            this.LanguageKey = "settingsbase";
-        }
+        IsPrimaryType = true;
+        ContainerTypes = new[] { typeof(ContentFolder) };
+        CommandIconClass = "epi-iconSettings";
+        IconClass = "epi-iconSettings";
+        LanguageKey = "settingsbase";
     }
 }

--- a/src/AddOn.Episerver.Settings/UI/SettingsComponent.cs
+++ b/src/AddOn.Episerver.Settings/UI/SettingsComponent.cs
@@ -21,34 +21,34 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace AddOn.Episerver.Settings.UI
-{
-    using EPiServer.Shell;
-    using EPiServer.Shell.ViewComposition;
+using EPiServer.Shell;
+using EPiServer.Shell.ViewComposition;
 
+namespace AddOn.Episerver.Settings.UI;
+
+/// <summary>
+///     Component that provides a tree based navigation for CMS pages.
+///     Implements the <see cref="ComponentDefinitionBase" />
+/// </summary>
+/// <seealso cref="ComponentDefinitionBase" />
+[Component]
+public sealed class SettingsComponent : ComponentDefinitionBase
+{
     /// <summary>
-    /// Component that provides a tree based navigation for CMS pages.
-    /// Implements the <see cref="ComponentDefinitionBase" />
+    ///     Initializes a new instance of the <see cref="SettingsComponent" /> class.
     /// </summary>
-    /// <seealso cref="ComponentDefinitionBase" />
-    [Component]
-    public sealed class SettingsComponent : ComponentDefinitionBase
+    public SettingsComponent()
+        : base("epi-cms/component/SharedBlocks")
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SettingsComponent"/> class.
-        /// </summary>
-        public SettingsComponent()
-            : base("epi-cms/component/SharedBlocks")
+        LanguagePath = "/episerver/cms/components/settings";
+        Title = "Settings";
+        SortOrder = 200;
+        Categories = new[]
         {
-            this.LanguagePath = "/episerver/cms/components/settings";
-            this.Title = "Settings";
-            this.SortOrder = 200;
-            this.Categories = new string[]
-                                  {
-                                      "cms"
-                                  };
-            this.PlugInAreas = new[] { PlugInArea.AssetsDefaultGroup };
-            this.Settings.Add(new Setting("repositoryKey", value: SettingsRepositoryDescriptor.RepositoryKey));
-        }
+            "cms"
+        };
+
+        PlugInAreas = new[] { PlugInArea.AssetsDefaultGroup };
+        Settings.Add(new Setting("repositoryKey", SettingsRepositoryDescriptor.RepositoryKey));
     }
 }

--- a/src/AddOn.Episerver.Settings/UI/SettingsMenuProvider.cs
+++ b/src/AddOn.Episerver.Settings/UI/SettingsMenuProvider.cs
@@ -21,43 +21,44 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace AddOn.Episerver.Settings.UI
-{
-    using System.Collections.Generic;
-#if NET461
-    using EPiServer.Security;
+using EPiServer.Shell.Navigation;
+using System.Collections.Generic;
+
+namespace AddOn.Episerver.Settings.UI;
+
+#if NET48
+using EPiServer.Security;
+
 #else
     using EPiServer.Authorization;
 #endif
-    using EPiServer.Shell.Navigation;
 
+/// <summary>
+///     Provides menu items for the settings component.
+/// </summary>
+[MenuProvider]
+public class SettingsMenuProvider : IMenuProvider
+{
     /// <summary>
-    ///     Provides menu items for the settings component.
+    ///     Provides the CMS menu section and the CMS settings section.
     /// </summary>
-    [MenuProvider]
-    public class SettingsMenuProvider : IMenuProvider
+    /// <returns>
+    ///     A list of <see cref="MenuItem" />s that the provider exposes.
+    /// </returns>
+    public IEnumerable<MenuItem> GetMenuItems()
     {
-        /// <summary>
-        ///     Provides the CMS menu section and the CMS settings section.
-        /// </summary>
-        /// <returns>
-        ///     A list of <see cref="MenuItem" />s that the provider exposes.
-        /// </returns>
-        public IEnumerable<MenuItem> GetMenuItems()
+        var cmsGlobalSettings = new UrlMenuItem(
+        "Global settings",
+        "/global/cms/settings",
+        "/episerver/AddOn.Episerver.Settings/settings")
         {
-            UrlMenuItem cmsGlobalSettings = new UrlMenuItem(
-                                                "Global settings",
-                                                "/global/cms/settings",
-                                                "/episerver/AddOn.Episerver.Settings/settings")
-            {
-#if NET461
-                IsAvailable = request => PrincipalInfo.HasAdminAccess
+#if NET48
+            IsAvailable = request => PrincipalInfo.HasAdminAccess
 #else
                 IsAvailable = request => request.User.IsInRole(Roles.CmsAdmins)
 #endif
-            };
+        };
 
-            return new MenuItem[] { cmsGlobalSettings };
-        }
+        return new MenuItem[] { cmsGlobalSettings };
     }
 }

--- a/src/AddOn.Episerver.Settings/UI/SettingsReferenceEditorDescriptor.cs
+++ b/src/AddOn.Episerver.Settings/UI/SettingsReferenceEditorDescriptor.cs
@@ -21,31 +21,23 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace AddOn.Episerver.Settings.UI
+using AddOn.Episerver.Settings.Core;
+using EPiServer.Core;
+using EPiServer.Shell.ObjectEditing.EditorDescriptors;
+
+namespace AddOn.Episerver.Settings.UI;
+
+/// <summary>
+///     Editor descriptor that will create a block selector.
+///     Implements the <see cref="ContentReferenceEditorDescriptor{SettingsBase}" />
+/// </summary>
+/// <seealso cref="ContentReferenceEditorDescriptor{SettingsBase}" />
+[EditorDescriptorRegistration(TargetType = typeof(ContentReference), UIHint = "dynamicsettings")]
+public class SettingsReferenceEditorDescriptor : ContentReferenceEditorDescriptor<SettingsBase>
 {
-    using AddOn.Episerver.Settings.Core;
-
-    using EPiServer.Core;
-    using EPiServer.Shell.ObjectEditing.EditorDescriptors;
-
     /// <summary>
-    /// Editor descriptor that will create a block selector.
-    /// Implements the <see cref="ContentReferenceEditorDescriptor{SettingsBase}" />
+    ///     Gets the repository key.
     /// </summary>
-    /// <seealso cref="ContentReferenceEditorDescriptor{SettingsBase}" />
-    [EditorDescriptorRegistration(TargetType = typeof(ContentReference), UIHint = "dynamicsettings")]
-    public class SettingsReferenceEditorDescriptor : ContentReferenceEditorDescriptor<SettingsBase>
-    {
-        /// <summary>
-        /// Gets the repository key.
-        /// </summary>
-        /// <value>The repository key.</value>
-        public override string RepositoryKey
-        {
-            get
-            {
-                return SettingsRepositoryDescriptor.RepositoryKey;
-            }
-        }
-    }
+    /// <value>The repository key.</value>
+    public override string RepositoryKey => SettingsRepositoryDescriptor.RepositoryKey;
 }

--- a/src/AddOn.Episerver.Settings/UI/SettingsRepositoryDescriptor.cs
+++ b/src/AddOn.Episerver.Settings/UI/SettingsRepositoryDescriptor.cs
@@ -21,175 +21,110 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-using EPiServer.Licensing.Services;
+using AddOn.Episerver.Settings.Core;
+using EPiServer.Cms.Shell.UI.CompositeViews.Internal;
+using EPiServer.Core;
+using EPiServer.Framework.Localization;
+using EPiServer.ServiceLocation;
+using EPiServer.Shell;
+using System;
+using System.Collections.Generic;
 
-namespace AddOn.Episerver.Settings.UI
+namespace AddOn.Episerver.Settings.UI;
+
+/// <summary>
+///     Class SettingsRepositoryDescriptor.
+///     Implements the <see cref="ContentRepositoryDescriptorBase" />
+/// </summary>
+/// <seealso cref="ContentRepositoryDescriptorBase" />
+[ServiceConfiguration(typeof(IContentRepositoryDescriptor))]
+public class SettingsRepositoryDescriptor : ContentRepositoryDescriptorBase
 {
-    using System;
-    using System.Collections.Generic;
-
-    using AddOn.Episerver.Settings.Core;
-
-    using EPiServer.Cms.Shell.UI.CompositeViews.Internal;
-    using EPiServer.Core;
-    using EPiServer.Framework.Localization;
-    using EPiServer.ServiceLocation;
-    using EPiServer.Shell;
+    /// <summary>
+    ///     Gets the repository key.
+    /// </summary>
+    /// <value>The repository key.</value>
+    public static string RepositoryKey => "dynamiccontent";
 
     /// <summary>
-    /// Class SettingsRepositoryDescriptor.
-    /// Implements the <see cref="ContentRepositoryDescriptorBase" />
+    ///     Gets the contained types.
     /// </summary>
-    /// <seealso cref="ContentRepositoryDescriptorBase" />
-    [ServiceConfiguration(typeof(IContentRepositoryDescriptor))]
-    public class SettingsRepositoryDescriptor : ContentRepositoryDescriptorBase
+    /// <value>The contained types.</value>
+    public override IEnumerable<Type> ContainedTypes
     {
-        /// <summary>
-        /// Gets the repository key.
-        /// </summary>
-        /// <value>The repository key.</value>
-        public static string RepositoryKey
-        {
-            get
-            {
-                return "dynamiccontent";
-            }
-        }
-
-        /// <summary>
-        /// Gets the contained types.
-        /// </summary>
-        /// <value>The contained types.</value>
-        public override IEnumerable<Type> ContainedTypes
-        {
-            get
-            {
-                return new[] { typeof(ContentFolder), typeof(SettingsBase) };
-            }
-        }
-
-        /// <summary>
-        /// Gets the creatable types.
-        /// </summary>
-        /// <value>The creatable types.</value>
-        public override IEnumerable<Type> CreatableTypes
-        {
-            get
-            {
-                return new[] { typeof(SettingsBase) };
-            }
-        }
-
-        /// <summary>
-        /// Gets the custom navigation widget.
-        /// </summary>
-        /// <value>The custom navigation widget.</value>
-        public override string CustomNavigationWidget
-        {
-            get
-            {
-                return "epi-cms/component/PageNavigationTree";
-            }
-        }
-
-        /// <summary>
-        /// Gets the custom select title.
-        /// </summary>
-        /// <value>The custom select title.</value>
-        public override string CustomSelectTitle
-        {
-            get
-            {
-                return LocalizationService.Current.GetString("/contentrepositories/settings/customselecttitle");
-            }
-        }
-
-        /// <summary>
-        /// Gets the key.
-        /// </summary>
-        /// <value>The key.</value>
-        public override string Key
-        {
-            get
-            {
-                return RepositoryKey;
-            }
-        }
-
-        /// <summary>
-        /// Gets the main navigation types.
-        /// </summary>
-        /// <value>The main navigation types.</value>
-        public override IEnumerable<Type> MainNavigationTypes
-        {
-            get
-            {
-                return new[] { typeof(ContentFolder) };
-            }
-        }
-
-        /// <summary>
-        /// Gets the main views.
-        /// </summary>
-        /// <value>The main views.</value>
-        public override IEnumerable<string> MainViews
-        {
-            get
-            {
-                return new[] { HomeView.ViewName };
-            }
-        }
-
-        /// <summary>
-        /// Gets the name.
-        /// </summary>
-        /// <value>The name.</value>
-        public override string Name
-        {
-            get
-            {
-                return LocalizationService.Current.GetString("/contentrepositories/settings/name");
-            }
-        }
-
-        /// <summary>
-        /// Gets the roots.
-        /// </summary>
-        /// <value>The roots.</value>
-        public override IEnumerable<ContentReference> Roots
-        {
-            get
-            {
-                return this.Settings.Service.SettingsRoots;
-            }
-        }
-
-        /// <summary>
-        /// Gets the search area.
-        /// </summary>
-        /// <value>The search area.</value>
-        public override string SearchArea
-        {
-            get
-            {
-                return SettingsSearchProvider.SearchArea;
-            }
-        }
-
-        /// <summary>
-        /// Gets the sort order.
-        /// </summary>
-        /// <value>The sort order.</value>
-        public override int SortOrder
-        {
-            get
-            {
-                return 1100;
-            }
-        }
-        
-        public bool EnableContextualContent => true;
-
-        private Injected<ISettingsService> Settings { get; set; }
+        get { return new[] { typeof(ContentFolder), typeof(SettingsBase) }; }
     }
+
+    /// <summary>
+    ///     Gets the creatable types.
+    /// </summary>
+    /// <value>The creatable types.</value>
+    public override IEnumerable<Type> CreatableTypes
+    {
+        get { return new[] { typeof(SettingsBase) }; }
+    }
+
+    /// <summary>
+    ///     Gets the custom navigation widget.
+    /// </summary>
+    /// <value>The custom navigation widget.</value>
+    public override string CustomNavigationWidget => "epi-cms/component/PageNavigationTree";
+
+    /// <summary>
+    ///     Gets the custom select title.
+    /// </summary>
+    /// <value>The custom select title.</value>
+    public override string CustomSelectTitle => LocalizationService.Current.GetString("/contentrepositories/settings/customselecttitle");
+
+    /// <summary>
+    ///     Gets the key.
+    /// </summary>
+    /// <value>The key.</value>
+    public override string Key => RepositoryKey;
+
+    /// <summary>
+    ///     Gets the main navigation types.
+    /// </summary>
+    /// <value>The main navigation types.</value>
+    public override IEnumerable<Type> MainNavigationTypes
+    {
+        get { return new[] { typeof(ContentFolder) }; }
+    }
+
+    /// <summary>
+    ///     Gets the main views.
+    /// </summary>
+    /// <value>The main views.</value>
+    public override IEnumerable<string> MainViews
+    {
+        get { return new[] { HomeView.ViewName }; }
+    }
+
+    /// <summary>
+    ///     Gets the name.
+    /// </summary>
+    /// <value>The name.</value>
+    public override string Name => LocalizationService.Current.GetString("/contentrepositories/settings/name");
+
+    /// <summary>
+    ///     Gets the roots.
+    /// </summary>
+    /// <value>The roots.</value>
+    public override IEnumerable<ContentReference> Roots => Settings.Service.SettingsRoots;
+
+    /// <summary>
+    ///     Gets the search area.
+    /// </summary>
+    /// <value>The search area.</value>
+    public override string SearchArea => SettingsSearchProvider.SearchArea;
+
+    /// <summary>
+    ///     Gets the sort order.
+    /// </summary>
+    /// <value>The sort order.</value>
+    public override int SortOrder => 1100;
+
+    public bool EnableContextualContent => true;
+
+    private Injected<ISettingsService> Settings { get; set; }
 }

--- a/src/AddOn.Episerver.Settings/UI/SettingsSearchProvider.cs
+++ b/src/AddOn.Episerver.Settings/UI/SettingsSearchProvider.cs
@@ -21,157 +21,154 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace AddOn.Episerver.Settings.UI
+using AddOn.Episerver.Settings.Core;
+using EPiServer;
+using EPiServer.Cms.Shell.Search;
+using EPiServer.Core;
+using EPiServer.DataAbstraction;
+using EPiServer.Framework.Localization;
+using EPiServer.Globalization;
+using EPiServer.ServiceLocation;
+using EPiServer.Shell;
+using EPiServer.Shell.Search;
+using EPiServer.Web;
+using EPiServer.Web.Routing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AddOn.Episerver.Settings.UI;
+
+/// <summary>
+///     Class SettingsSearchProvider.
+/// </summary>
+[SearchProvider]
+public class SettingsSearchProvider : ContentSearchProviderBase<SettingsBase, ContentType>
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
+    internal const string SearchArea = "Settings/settings";
 
-    using AddOn.Episerver.Settings.Core;
+    private readonly IContentLoader contentLoader;
 
-    using EPiServer;
-    using EPiServer.Cms.Shell.Search;
-    using EPiServer.Core;
-    using EPiServer.DataAbstraction;
-    using EPiServer.Framework.Localization;
-    using EPiServer.Globalization;
-    using EPiServer.ServiceLocation;
-    using EPiServer.Shell;
-    using EPiServer.Shell.Search;
-    using EPiServer.Web;
-    using EPiServer.Web.Routing;
+    private readonly LocalizationService localizationService;
+
+    private readonly ISettingsService settingsService;
 
     /// <summary>
-    /// Class SettingsSearchProvider.
+    ///     Initializes a new instance of the <see cref="SettingsSearchProvider" /> class.
     /// </summary>
-    [SearchProvider]
-    public class SettingsSearchProvider : ContentSearchProviderBase<SettingsBase, ContentType>
-    {
-        internal const string SearchArea = "Settings/settings";
-
-        private readonly IContentLoader contentLoader;
-
-        private readonly LocalizationService localizationService;
-
-        private readonly ISettingsService settingsService;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SettingsSearchProvider" /> class.
-        /// </summary>
-        /// <param name="localizationService">The localization service.</param>
-        /// <param name="siteDefinitionResolver">The site definition resolver.</param>
-        /// <param name="contentTypeRepository">The content type repository.</param>
-        /// <param name="editUrlResolver">The edit URL resolver.</param>
-        /// <param name="currentSiteDefinition">The current site definition.</param>
-        /// <param name="languageResolver">The language resolver.</param>
-        /// <param name="urlResolver">The URL resolver.</param>
-        /// <param name="templateResolver">The template resolver.</param>
-        /// <param name="uiDescriptorRegistry">The UI descriptor registry.</param>
-        /// <param name="contentLoader">The content loader.</param>
-        /// <param name="settingsService">The settings service.</param>
-        public SettingsSearchProvider(
-            LocalizationService localizationService,
-            ISiteDefinitionResolver siteDefinitionResolver,
-            IContentTypeRepository<ContentType> contentTypeRepository,
-            EditUrlResolver editUrlResolver,
-            ServiceAccessor<SiteDefinition> currentSiteDefinition,
-#if NET461
-            LanguageResolver languageResolver,
+    /// <param name="localizationService">The localization service.</param>
+    /// <param name="siteDefinitionResolver">The site definition resolver.</param>
+    /// <param name="contentTypeRepository">The content type repository.</param>
+    /// <param name="editUrlResolver">The edit URL resolver.</param>
+    /// <param name="currentSiteDefinition">The current site definition.</param>
+    /// <param name="languageResolver">The language resolver.</param>
+    /// <param name="urlResolver">The URL resolver.</param>
+    /// <param name="templateResolver">The template resolver.</param>
+    /// <param name="uiDescriptorRegistry">The UI descriptor registry.</param>
+    /// <param name="contentLoader">The content loader.</param>
+    /// <param name="settingsService">The settings service.</param>
+    public SettingsSearchProvider(
+        LocalizationService localizationService,
+        ISiteDefinitionResolver siteDefinitionResolver,
+        IContentTypeRepository<ContentType> contentTypeRepository,
+        EditUrlResolver editUrlResolver,
+        ServiceAccessor<SiteDefinition> currentSiteDefinition,
+#if NET48
+        LanguageResolver languageResolver,
 #else
             IContentLanguageAccessor languageResolver,
 #endif
-            UrlResolver urlResolver,
-            TemplateResolver templateResolver,
-            UIDescriptorRegistry uiDescriptorRegistry,
-            IContentLoader contentLoader,
-            ISettingsService settingsService)
-            : base(
-                localizationService: localizationService,
-                siteDefinitionResolver: siteDefinitionResolver,
-                contentTypeRepository: contentTypeRepository,
-                editUrlResolver: editUrlResolver,
-                currentSiteDefinition: currentSiteDefinition,
-                languageResolver: languageResolver,
-                urlResolver: urlResolver,
-                templateResolver: templateResolver,
-                uiDescriptorRegistry: uiDescriptorRegistry)
+        UrlResolver urlResolver,
+        TemplateResolver templateResolver,
+        UIDescriptorRegistry uiDescriptorRegistry,
+        IContentLoader contentLoader,
+        ISettingsService settingsService)
+        : base(
+        localizationService,
+        siteDefinitionResolver,
+        contentTypeRepository,
+        editUrlResolver,
+        currentSiteDefinition,
+        languageResolver,
+        urlResolver,
+        templateResolver,
+        uiDescriptorRegistry)
+    {
+        this.contentLoader = contentLoader;
+        this.settingsService = settingsService;
+        this.localizationService = localizationService;
+    }
+
+    /// <summary>
+    ///     Gets the area.
+    /// </summary>
+    /// <value>The area.</value>
+    public override string Area => SearchArea;
+
+    /// <summary>
+    ///     Gets the category.
+    /// </summary>
+    /// <value>The category.</value>
+    public override string Category => localizationService.GetString("/episerver/cms/components/settings/title");
+
+    /// <summary>
+    ///     Gets the icon CSS class.
+    /// </summary>
+    /// <value>The icon CSS class.</value>
+    override protected string IconCssClass => "epi-iconSettings";
+
+    /// <summary>
+    ///     Searches the specified query.
+    /// </summary>
+    /// <param name="query">The query.</param>
+    /// <returns>An <see cref="IEnumerable{T}" /> of <see cref="SearchResult" />.</returns>
+    public override IEnumerable<SearchResult> Search(Query query)
+    {
+        if (string.IsNullOrWhiteSpace(query?.SearchQuery) || query.SearchQuery.Trim().Length < 2)
         {
-            this.contentLoader = contentLoader;
-            this.settingsService = settingsService;
-            this.localizationService = localizationService;
+            return Enumerable.Empty<SearchResult>();
         }
 
-        /// <summary>
-        /// Gets the area.
-        /// </summary>
-        /// <value>The area.</value>
-        public override string Area => SearchArea;
+        var searchResultList = new List<SearchResult>();
+        var str = query.SearchQuery.Trim();
 
-        /// <summary>
-        /// Gets the category.
-        /// </summary>
-        /// <value>The category.</value>
-        public override string Category => this.localizationService.GetString("/episerver/cms/components/settings/title");
 
-        /// <summary>
-        /// Gets the icon CSS class.
-        /// </summary>
-        /// <value>The icon CSS class.</value>
-        protected override string IconCssClass => "epi-iconSettings";
+        var settings = settingsService.SettingsRoots.SelectMany(root => contentLoader.GetDescendents(root));
 
-        /// <summary>
-        /// Searches the specified query.
-        /// </summary>
-        /// <param name="query">The query.</param>
-        /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="SearchResult"/>.</returns>
-        public override IEnumerable<SearchResult> Search(Query query)
+        foreach (var contentReference in settings)
         {
-            if (string.IsNullOrWhiteSpace(value: query?.SearchQuery) || query.SearchQuery.Trim().Length < 2)
+            SettingsBase setting;
+
+            if (!contentLoader.TryGet(contentReference, out setting))
             {
-                return Enumerable.Empty<SearchResult>();
+                continue;
             }
 
-            List<SearchResult> searchResultList = new List<SearchResult>();
-            string str = query.SearchQuery.Trim();
-
-            
-            IEnumerable<ContentReference> settings = this.settingsService.SettingsRoots.SelectMany(root => this.contentLoader.GetDescendents(contentLink: root));
-
-            foreach (ContentReference contentReference in settings)
+            if (setting.Name.IndexOf(str, StringComparison.OrdinalIgnoreCase) < 0)
             {
-                SettingsBase setting;
-
-                if (!this.contentLoader.TryGet(contentLink: contentReference, content: out setting))
-                {
-                    continue;
-                }
-
-                if (setting.Name.IndexOf(value: str, comparisonType: StringComparison.OrdinalIgnoreCase) < 0)
-                {
-                    continue;
-                }
-
-                searchResultList.Add(this.CreateSearchResult(contentData: setting));
-
-                if (searchResultList.Count == query.MaxResults)
-                {
-                    break;
-                }
+                continue;
             }
 
-            return searchResultList;
+            searchResultList.Add(CreateSearchResult(setting));
+
+            if (searchResultList.Count == query.MaxResults)
+            {
+                break;
+            }
         }
 
-        /// <summary>
-        /// Creates the preview text.
-        /// </summary>
-        /// <param name="content">The content.</param>
-        /// <returns>The preview text.</returns>
-        protected override string CreatePreviewText(IContentData content)
-        {
-            return content == null
-                       ? string.Empty
-                       : $"{((SettingsBase)content).Name} {this.localizationService.GetString("/contentrepositories/settings/customselecttitle").ToLower()}";
-        }
+        return searchResultList;
+    }
+
+    /// <summary>
+    ///     Creates the preview text.
+    /// </summary>
+    /// <param name="content">The content.</param>
+    /// <returns>The preview text.</returns>
+    override protected string CreatePreviewText(IContentData content)
+    {
+        return content == null
+            ? string.Empty
+            : $"{((SettingsBase)content).Name} {localizationService.GetString("/contentrepositories/settings/customselecttitle").ToLower()}";
     }
 }


### PR DESCRIPTION
Ran an automated code clean set to some modern standard on the solution mostly to get the usings to the top. Also unnested the namespaces. I see it also shortened som getters and shifted into using vars. I'm fine with this style but let me know if it's not how it should be, and I'll see if I can configure it into not touching those parts of the code.

Also bumped the framework to 4.8 to keep the cms 11 aligned with the times...