### PR TITLE
Adds and changes the API:s for getting settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,28 +97,32 @@ public virtual ContentReference GoogleAnalyticsSettings { get; set; }
 
 If upgrading from version 2 *AND* and sites in the solution has had site specific assets enabled.
 
-1. Upgrade to version 3.x
+1. Upgrade to version 3.x or newer
 2. Using the blocks gadget, locate the folder "For this site / Settings Root"
 3. Move it into "For all sites / Settings Root"
 4. Now all settings are available in the settings gadget so that they can be moved into the specific site they target (or being kept as shared)
 
 ## Getting a setting
-To get a settings instance from your code you use the ISettingsService. It has a number of methods for resolving settings depending on the need.
+To get a settings instance from your code you use the ISettingsService. It has a number of methods for resolving settings depending on the need. 
 
 ```csharp
 ISettingsService settingsService = ServiceLocator.Current.GetInstance<ISettingsService>();
 
 // Will resolve the first menuSetting found, starting from the current content context
 settingsService.GetSetting<MenuSettings>();
+settingsService.GetSetting(typeof(MenuSettings));
 
 // Will resolve the first menuSetting found, starting from the provided content reference
 settingsService.GetSetting<MenuSettings>(myContentReference);
+settingsService.GetSetting(typeof(MenuSettings), myContentReference));
 
 // Will resolve the first menuSetting found, starting from the provided content
 settingsService.GetSetting<MenuSettings>(myContentInstance);
+settingsService.GetSetting(typeof(MenuSettings), myContentInstance));
 
 // Will resolve a menuSetting only from the global settings
 settingsService.GetGlobalSetting<MenuSettings>();
+settingsService.GetGlobalSetting(typeof(MenuSettings));
 
 // Will resolve all menuSettings found, starting from the provided content reference
 settingsService.GetSettingsRecursive<MenuSettings>(myContentReference);
@@ -128,6 +132,8 @@ settingsService.GetSettingsRecursive<MenuSettings>(myContentInstance);
 ```
 
 The default settings resolver will traverse the structure and look for properties with the same name as the settings type, in this case "MenuSettings", and return the first property with a defined value. Since the settings are matched by name - you can implement settings across content types.
+
+As seen in the examples, most methods have overloads to either use generics or a *Type* argument to use in cases where the type is not known at compile time.
 
 If you want to clarify that a content types is a source of a certain type of settings - you can create your own interface to declare this. However, this is not something that the settings system will use.
 

--- a/README.md
+++ b/README.md
@@ -75,16 +75,6 @@ public virtual ContentReference MenuSettings { get; set; }
 
 Once you have created your setting you can assign the value of your page property to connect them.
 
-4. Getting the settings
-```csharp
-ISettingsService settingsService = ServiceLocator.Current.GetInstance<ISettingsService>();
-settingsService.GetSettings<MenuSettings>(currentPage);
-```
-
-Note that the call to get these settings include the current content object. The default settings resolver will traverse the structure and look for properties with the same name as the settings type, in this case "MenuSettings", and return the first property with a defined value. Since the settings are matched by name - you can implement settings across content types.
-
-If you want to clarify that a content types is a source of a certain type of settings - you can create your own interface to declare this. However, this is not something that the settings system will use.
-
 ### Combining local and global settings
 
 You can even combine local settings with global settings where the global setting will be used as a fallback if there are no local settings defined in the requested content hierarchy. If you want to try this, you can do the following:
@@ -112,10 +102,39 @@ If upgrading from version 2 *AND* and sites in the solution has had site specifi
 3. Move it into "For all sites / Settings Root"
 4. Now all settings are available in the settings gadget so that they can be moved into the specific site they target (or being kept as shared)
 
+## Getting a setting
+To get a settings instance from your code you use the ISettingsService. It has a number of methods for resolving settings depending on the need.
+
+```csharp
+ISettingsService settingsService = ServiceLocator.Current.GetInstance<ISettingsService>();
+
+// Will resolve the first menuSetting found, starting from the current content context
+settingsService.GetSetting<MenuSettings>();
+
+// Will resolve the first menuSetting found, starting from the provided content reference
+settingsService.GetSetting<MenuSettings>(myContentReference);
+
+// Will resolve the first menuSetting found, starting from the provided content
+settingsService.GetSetting<MenuSettings>(myContentInstance);
+
+// Will resolve a menuSetting only from the global settings
+settingsService.GetGlobalSetting<MenuSettings>();
+
+// Will resolve all menuSettings found, starting from the provided content reference
+settingsService.GetSettingsRecursive<MenuSettings>(myContentReference);
+
+// Will resolve all menuSettings found, starting from the provided content
+settingsService.GetSettingsRecursive<MenuSettings>(myContentInstance);
+```
+
+The default settings resolver will traverse the structure and look for properties with the same name as the settings type, in this case "MenuSettings", and return the first property with a defined value. Since the settings are matched by name - you can implement settings across content types.
+
+If you want to clarify that a content types is a source of a certain type of settings - you can create your own interface to declare this. However, this is not something that the settings system will use.
+
 ## Customize how settings are resolved
 By default, settings are resolved by searching for properties with name matching the Settings type. If you wish to add a custom way for this, it is possible to add a class implementing __ISettingsResolver__. For example this gives the power to have nested settings.
 
-The registered resolvers are ordered by the SortOrder property will be called for each IContent item traversed. The first resolver that returns a setting will "win" and that setting will be the on used.
+The registered resolvers are ordered by the SortOrder property and will be called for each IContent item traversed. The first resolver that returns a setting will "win" and that setting will be the on used.
 
 Implement a class:
 ```csharp

--- a/src/AddOn.Episerver.Settings.sln
+++ b/src/AddOn.Episerver.Settings.sln
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Files", "Solution 
 		..\.github\workflows\dotnet.yml = ..\.github\workflows\dotnet.yml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Addon.Episerver.Settings.Test", "Addon.Episerver.Settings.Test\Addon.Episerver.Settings.Test.csproj", "{D6000721-07E2-4FAE-BE0A-610304EBD463}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{D999E2CF-F01E-48E6-85ED-98AEEE83B6FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D999E2CF-F01E-48E6-85ED-98AEEE83B6FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D999E2CF-F01E-48E6-85ED-98AEEE83B6FB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D6000721-07E2-4FAE-BE0A-610304EBD463}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6000721-07E2-4FAE-BE0A-610304EBD463}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6000721-07E2-4FAE-BE0A-610304EBD463}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6000721-07E2-4FAE-BE0A-610304EBD463}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/AddOn.Episerver.Settings/AddOn.Episerver.Settings.csproj
+++ b/src/AddOn.Episerver.Settings/AddOn.Episerver.Settings.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>AddOn.Episerver.Settings</RootNamespace>
     <AssemblyName>AddOn.Episerver.Settings</AssemblyName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>4.0.0</PackageVersion>
+    <PackageVersion>5.0.0</PackageVersion>
     <LangVersion>10</LangVersion>
     <TargetFrameworks>net48;net6.0;net7.0</TargetFrameworks>
     <IsPackable>true</IsPackable>

--- a/src/AddOn.Episerver.Settings/Core/ISettingsService.cs
+++ b/src/AddOn.Episerver.Settings/Core/ISettingsService.cs
@@ -71,6 +71,14 @@ public interface ISettingsService
     /// <param name="contentLink">The content link.</param>
     /// <returns>An instance of <typeparamref name="T" /></returns>
     T GetSetting<T>(ContentReference contentLink) where T : SettingsBase;
+
+    /// <summary>
+    ///     Gets the first matching setting by traversing the content tree, starting the search from the provided content reference.
+    /// </summary>
+    /// <param name="settingsType">The settings type</param>
+    /// <param name="contentLink">The content link.</param>
+    /// <returns>An instance of <typeparamref name="SettingsBase" /></returns>
+    SettingsBase GetSetting(Type settingsType, ContentReference contentLink);
     
     /// <summary>
     ///     Gets the first matching setting by traversing the content tree, starting the search from the provided content.
@@ -81,11 +89,27 @@ public interface ISettingsService
     T GetSetting<T>(IContent content) where T : SettingsBase;
     
     /// <summary>
+    ///     Gets the first matching setting by traversing the content tree, starting the search from the provided content.
+    /// </summary>
+    /// <param name="settingsType">The settings type</param>
+    /// <param name="content">The content where to start the search.</param>
+    /// <returns><typeparamref name="SettingsBase" /></returns>
+    SettingsBase GetSetting(Type settingsType, IContent content);
+    
+    /// <summary>
     ///     Gets the setting implementing the specified type from the global settings repository.
     /// </summary>
     /// <typeparam name="T">The settings type</typeparam>
     /// <returns>An instance of <typeparamref name="T" /></returns>
     T GetGlobalSetting<T>() where T : SettingsBase;
+    
+    /// <summary>
+    ///     Gets the setting implementing the specified type from the global settings repository.
+    /// </summary>
+    /// <param name="settingsType">The settings type</param>
+    /// <returns>An instance of <typeparamref name="SettingsBase" /> </returns>
+    /// <exception cref="ArgumentException">It type does not inherit from <typeparamref name="SettingsBase" /></exception>
+    SettingsBase GetGlobalSetting(Type settingsType);
 
     /// <summary>
     ///     Gets all settings found traversing the content tree starting from the provided content link.

--- a/src/AddOn.Episerver.Settings/Core/ISettingsService.cs
+++ b/src/AddOn.Episerver.Settings/Core/ISettingsService.cs
@@ -63,13 +63,19 @@ public interface ISettingsService
     /// <typeparam name="T">The settings type</typeparam>
     /// <returns>An instance of <typeparamref name="T" /></returns>
     T GetSetting<T>() where T : SettingsBase;
+    
+    /// <summary>
+    ///     Gets the first matching setting by traversing the content tree, starting the search for it from the current content context.
+    /// </summary>
+    /// <returns>An instance of <see cref="SettingsBase" /></returns>
+    SettingsBase GetSetting(Type settingsType);
 
     /// <summary>
     ///     Gets the first matching setting by traversing the content tree, starting the search from the provided content reference.
     /// </summary>
     /// <typeparam name="T">The settings type</typeparam>
     /// <param name="contentLink">The content link.</param>
-    /// <returns>An instance of <typeparamref name="T" /></returns>
+    /// <returns>An instance of <see cref="SettingsBase" />></returns>
     T GetSetting<T>(ContentReference contentLink) where T : SettingsBase;
 
     /// <summary>
@@ -77,7 +83,7 @@ public interface ISettingsService
     /// </summary>
     /// <param name="settingsType">The settings type</param>
     /// <param name="contentLink">The content link.</param>
-    /// <returns>An instance of <typeparamref name="SettingsBase" /></returns>
+    /// <returns>An instance of <see cref="SettingsBase" /></returns>
     SettingsBase GetSetting(Type settingsType, ContentReference contentLink);
     
     /// <summary>
@@ -93,7 +99,7 @@ public interface ISettingsService
     /// </summary>
     /// <param name="settingsType">The settings type</param>
     /// <param name="content">The content where to start the search.</param>
-    /// <returns><typeparamref name="SettingsBase" /></returns>
+    /// <returns><see cref="SettingsBase" /></returns>
     SettingsBase GetSetting(Type settingsType, IContent content);
     
     /// <summary>
@@ -107,7 +113,7 @@ public interface ISettingsService
     ///     Gets the setting implementing the specified type from the global settings repository.
     /// </summary>
     /// <param name="settingsType">The settings type</param>
-    /// <returns>An instance of <typeparamref name="SettingsBase" /> </returns>
+    /// <returns>An instance of <see cref="SettingsBase" /></returns>
     /// <exception cref="ArgumentException">It type does not inherit from <typeparamref name="SettingsBase" /></exception>
     SettingsBase GetGlobalSetting(Type settingsType);
 

--- a/src/AddOn.Episerver.Settings/Core/ISettingsService.cs
+++ b/src/AddOn.Episerver.Settings/Core/ISettingsService.cs
@@ -58,20 +58,48 @@ public interface ISettingsService
     IEnumerable<ContentReference> SettingsRoots { get; }
 
     /// <summary>
-    ///     Gets the settings.
+    ///     Gets the first matching setting by traversing the content tree, starting the search for it from the current content context.
     /// </summary>
     /// <typeparam name="T">The settings type</typeparam>
     /// <returns>An instance of <typeparamref name="T" /></returns>
-        T GetSettings<T>() where T : SettingsBase;
+    T GetSetting<T>() where T : SettingsBase;
 
     /// <summary>
-    ///     Gets the settings.
+    ///     Gets the first matching setting by traversing the content tree, starting the search from the provided content reference.
+    /// </summary>
+    /// <typeparam name="T">The settings type</typeparam>
+    /// <param name="contentLink">The content link.</param>
+    /// <returns>An instance of <typeparamref name="T" /></returns>
+    T GetSetting<T>(ContentReference contentLink) where T : SettingsBase;
+    
+    /// <summary>
+    ///     Gets the first matching setting by traversing the content tree, starting the search from the provided content.
     /// </summary>
     /// <typeparam name="T">The settings type</typeparam>
     /// <param name="content">The content.</param>
     /// <returns>An instance of <typeparamref name="T" /></returns>
-    T GetSettings<T>(IContent content)
-            where T : SettingsBase;
+    T GetSetting<T>(IContent content) where T : SettingsBase;
+    
+    /// <summary>
+    ///     Gets the setting implementing the specified type from the global settings repository.
+    /// </summary>
+    /// <typeparam name="T">The settings type</typeparam>
+    /// <returns>An instance of <typeparamref name="T" /></returns>
+    T GetGlobalSetting<T>() where T : SettingsBase;
+
+    /// <summary>
+    ///     Gets all settings found traversing the content tree starting from the provided content link.
+    /// </summary>
+    /// <typeparam name="T">The settings type</typeparam>
+    /// <returns>An instance of <typeparamref name="T" /></returns>
+    IEnumerable<T> GetSettingsRecursive<T>(ContentReference contentLink) where T : SettingsBase;
+    
+    /// <summary>
+    ///     Gets all settings found traversing the content tree starting from the provided content.
+    /// </summary>
+    /// <typeparam name="T">The settings type</typeparam>
+    /// <returns>An instance of <typeparamref name="T" /></returns>
+    IEnumerable<T> GetSettingsRecursive<T>(IContent content) where T : SettingsBase;
 
     /// <summary>
     ///     Initializes the settings.
@@ -88,6 +116,6 @@ public interface ISettingsService
     /// <summary>
     ///     Updates the settings root folder for a site.
     /// </summary>
-    /// <param name="SiteDefinition">The site definition.</param>
+    /// <param name="siteDefinition">The site definition.</param>
     ContentReference ValidateOrCreateSiteSettingsRoot(SiteDefinition siteDefinition);
 }

--- a/src/AddOn.Episerver.Settings/Core/SettingsService.cs
+++ b/src/AddOn.Episerver.Settings/Core/SettingsService.cs
@@ -285,6 +285,38 @@ public class SettingsService : ISettingsService
     }
 
     /// <summary>
+    ///     Gets the setting, starting the search at the current content context.
+    /// </summary>
+    /// <param name="settingsType">The settings type</param>
+    /// <returns>An instance of <see cref="SettingsBase" /> </returns>
+    /// <exception cref="T:System.Threading.SynchronizationLockException">
+    ///     The current thread has not entered the lock in read mode.
+    /// </exception>
+    /// <exception cref="T:System.Threading.LockRecursionException">
+    ///     The current thread cannot acquire the write lock when it
+    ///     holds the read lock.-or-The <see cref="P:System.Threading.ReaderWriterLockSlim.RecursionPolicy" /> property is
+    ///     <see cref="F:System.Threading.LockRecursionPolicy.NoRecursion" />, and the current thread has attempted to acquire
+    ///     the read lock when it already holds the read lock. -or-The
+    ///     <see cref="P:System.Threading.ReaderWriterLockSlim.RecursionPolicy" /> property is
+    ///     <see cref="F:System.Threading.LockRecursionPolicy.NoRecursion" />, and the current thread has attempted to acquire
+    ///     the read lock when it already holds the write lock. -or-The recursion number would exceed the capacity of the
+    ///     counter. This limit is so large that applications should never encounter this exception.
+    /// </exception>
+    /// <exception cref="T:System.ObjectDisposedException">
+    ///     The <see cref="T:System.Threading.ReaderWriterLockSlim" /> object
+    ///     has been disposed.
+    /// </exception>
+    public SettingsBase GetSetting(Type settingsType)
+    {
+        if (contentRouteHelper.Content is null)
+        {
+            return default;
+        }
+
+        return GetSetting(settingsType, contentRouteHelper.Content);
+    }
+
+    /// <summary>
     ///     Gets the setting, starting the search at the provided content link.
     /// </summary>
     /// <typeparam name="T">The settings type</typeparam>
@@ -322,7 +354,7 @@ public class SettingsService : ISettingsService
     /// </summary>
     /// <param name="settingsType">The settings type</param>
     /// <param name="contentLink">The content link</param>
-    /// <returns>An instance of <typeparamref name="SettingsBase" /></returns>
+    /// <returns>An instance of <see cref="SettingsBase" /></returns>
     public SettingsBase GetSetting(Type settingsType, ContentReference contentLink)
     {
         if (contentRepository.TryGet(contentLink, out IContent content))

--- a/src/Addon.Episerver.Settings.Test/Addon.Episerver.Settings.Test.csproj
+++ b/src/Addon.Episerver.Settings.Test/Addon.Episerver.Settings.Test.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="Moq" Version="4.17.2" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\AddOn.Episerver.Settings\AddOn.Episerver.Settings.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Addon.Episerver.Settings.Test/SettingsServiceTests.cs
+++ b/src/Addon.Episerver.Settings.Test/SettingsServiceTests.cs
@@ -1,0 +1,130 @@
+using AddOn.Episerver.Settings.Core;
+using EPiServer;
+using EPiServer.Core;
+using EPiServer.Framework.Cache;
+using EPiServer.Web.Routing;
+using Moq;
+
+namespace Addon.Episerver.Settings.Test;
+
+public class SettingsServiceTests
+{
+    [Fact]
+    public void GetSettingFromLinkShouldResolveAnExistingSetting()
+    {
+        var page1 = new Mock<TestPage>();
+        var pageLink = new PageReference(100);
+        var settingsLink = new ContentReference(200);
+        page1.Setup(page => page.ContentLink).Returns(pageLink);
+        page1.Setup(page => page.TestSetting).Returns(settingsLink);
+        var setting1 = new Mock<TestSetting>();
+        setting1.Setup(setting => setting.ContentLink).Returns(settingsLink);
+
+        var settingsService = SetupSettingsService( new PageData[] { page1.Object }, setting1.Object);
+
+        var result = settingsService.GetSetting(typeof(TestSetting), pageLink);
+        
+        Assert.Equal(setting1.Object, result);
+    }
+    
+    [Fact]
+    public void GetSettingFromContentShouldResolveAnExistingSetting()
+    {
+        var page1 = new Mock<TestPage>();
+        var pageLink = new PageReference(100);
+        var settingsLink = new ContentReference(200);
+        page1.Setup(page => page.ContentLink).Returns(pageLink);
+        page1.Setup(page => page.TestSetting).Returns(settingsLink);
+        var setting1 = new Mock<TestSetting>();
+        setting1.Setup(setting => setting.ContentLink).Returns(settingsLink);
+
+        var settingsService = SetupSettingsService( new PageData[] { page1.Object }, setting1.Object);
+
+        var result = settingsService.GetSetting(typeof(TestSetting), page1.Object);
+        
+        Assert.Equal(setting1.Object, result);
+    }
+    
+    [Fact]
+    public void GetSettingShouldReturnNullIfNoSettingExists()
+    {
+        var page1 = new Mock<TestPage>();
+        var pageLink = new PageReference(100);
+        page1.Setup(page => page.ContentLink).Returns(pageLink);
+        
+        var settingsService = SetupSettingsService( new PageData[] { page1.Object }, null);
+
+        var result = settingsService.GetSetting(typeof(TestSetting), page1.Object);
+        
+        Assert.Null(result);
+    }
+    
+    [Fact]
+    public void GetSettingShouldTraverseThePageTreeToResolveTheSetting()
+    {
+        var settingsLink = new ContentReference(200);
+        var setting1 = new Mock<TestSetting>();
+        setting1.Setup(setting => setting.ContentLink).Returns(settingsLink);
+        
+        var page1 = new Mock<TestPage>();
+        var pageLink1 = new PageReference(100);
+        var page2 = new Mock<TestPage>();
+        var pageLink2 = new PageReference(101);
+        page1.Setup(page => page.ContentLink).Returns(pageLink1);
+        page1.Setup(page => page.ParentLink).Returns(pageLink2);
+        page2.Setup(page => page.ContentLink).Returns(pageLink2);
+        page2.Setup(page => page.TestSetting).Returns(settingsLink);
+        
+        var settingsService = SetupSettingsService( new PageData[] { page1.Object, page2.Object }, setting1.Object);
+
+        var result = settingsService.GetSetting(typeof(TestSetting), page1.Object);
+        
+        Assert.Equal(setting1.Object, result);
+    }
+
+    private SettingsService SetupSettingsService(PageData[] pages, SettingsBase? result)
+    {
+        var contentRepository = new Mock<IContentRepository>();
+        var ancestorReferencesLoader = new Mock<AncestorReferencesLoader>();
+        var settingsResolver = new Mock<ISettingsResolver>();
+        var globalSettingsCache = new Mock<ISynchronizedObjectInstanceCache>();
+
+        IContent? content = null;
+        contentRepository.Setup(repository => repository.TryGet(It.IsAny<ContentReference>(), out content))
+            .Returns((ContentReference link, out IContent? c) =>
+            {
+                c = pages.FirstOrDefault(x => link.CompareToIgnoreWorkID(x.ContentLink));
+                return c != null;
+            });
+        
+        SettingsBase? setting = null;
+        settingsResolver.Setup(resolver => resolver.TryResolveSettingFromContent(It.IsAny<IContent>(), out setting))
+            .Returns((IContent c, out SettingsBase? s) =>
+            {
+                s = result;
+                return s != null;
+            });
+
+        ancestorReferencesLoader.Setup(loader => loader.GetAncestors(It.IsAny<ContentReference>()))
+            .Returns((ContentReference link) =>
+            {
+                return pages.SkipWhile(p => !p.ContentLink.CompareToIgnoreWorkID(link)).Skip(1)
+                    .Select(p => p.ContentLink).ToList();
+            });
+
+        
+        var settingsService = new SettingsService(
+            contentRepository.Object,
+            null,
+            null,
+            null,
+            null,
+            ancestorReferencesLoader.Object,
+            globalSettingsCache.Object,
+            new[] { settingsResolver.Object },
+            null
+        );
+
+        return settingsService;
+    }
+}

--- a/src/Addon.Episerver.Settings.Test/TestPage.cs
+++ b/src/Addon.Episerver.Settings.Test/TestPage.cs
@@ -1,0 +1,8 @@
+using EPiServer.Core;
+
+namespace Addon.Episerver.Settings.Test;
+
+public class TestPage : PageData
+{
+    public virtual ContentReference TestSetting { get; set; } = ContentReference.EmptyReference;
+}

--- a/src/Addon.Episerver.Settings.Test/TestSetting.cs
+++ b/src/Addon.Episerver.Settings.Test/TestSetting.cs
@@ -1,0 +1,7 @@
+using AddOn.Episerver.Settings.Core;
+
+namespace Addon.Episerver.Settings.Test;
+
+public class TestSetting : SettingsBase
+{
+}

--- a/src/Addon.Episerver.Settings.Test/Usings.cs
+++ b/src/Addon.Episerver.Settings.Test/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;


### PR DESCRIPTION
Changes the behavior to resolve settings starting from the current content context if no starting point is given.

Adds a more explicit call if one only want to get global settings.

Also provides a new API for getting all possible settings in the hierarchy.