### PR TITLE
Stops it being possible to create and move content into global settings

### DIFF
--- a/src/AddOn.Episerver.Settings/Resources/Epi.Libraries.Settings.EmbeddedLangFiles_DA.xml
+++ b/src/AddOn.Episerver.Settings/Resources/Epi.Libraries.Settings.EmbeddedLangFiles_DA.xml
@@ -84,6 +84,12 @@
       <deletesetting>
         <deletenotsupported>En global indstilling kan ikke slettes</deletenotsupported>
       </deletesetting>
+      <createsetting>
+        <createnotsupported>Det er ikke tilladt at oprette indhold i mappen med globale indstillinger</createnotsupported>
+      </createsetting>
+      <movesetting>
+        <contenttoglobalsetting>Det er ikke tilladt at flytte indhold til mappen med globale indstillinger</contenttoglobalsetting>
+      </movesetting>
     </edit>
   </language>
 </languages>

--- a/src/AddOn.Episerver.Settings/Resources/Epi.Libraries.Settings.EmbeddedLangFiles_DE.xml
+++ b/src/AddOn.Episerver.Settings/Resources/Epi.Libraries.Settings.EmbeddedLangFiles_DE.xml
@@ -84,6 +84,12 @@
       <deletesetting>
         <deletenotsupported>Eine globale Einstellung kann nicht gelöscht werden</deletenotsupported>
       </deletesetting>
+      <createsetting>
+        <createnotsupported>Das Erstellen von Inhalten im Ordner mit den globalen Einstellungen ist nicht zulässig</createnotsupported>
+      </createsetting>
+      <movesetting>
+        <contenttoglobalsetting>Das Verschieben von Inhalten in den Ordner mit den globalen Einstellungen ist nicht zulässig</contenttoglobalsetting>
+      </movesetting>
     </edit>
   </language>
 </languages>

--- a/src/AddOn.Episerver.Settings/Resources/Epi.Libraries.Settings.EmbeddedLangFiles_EN.xml
+++ b/src/AddOn.Episerver.Settings/Resources/Epi.Libraries.Settings.EmbeddedLangFiles_EN.xml
@@ -85,6 +85,12 @@
       <deletesetting>
         <deletenotsupported>A global setting cannot be deleted</deletenotsupported>
       </deletesetting>
+      <createsetting>
+        <createnotsupported>Creating content in the global settings folder is not allowed</createnotsupported>
+      </createsetting>
+      <movesetting>
+        <contenttoglobalsetting>Moving content into the global settings folder is not allowed</contenttoglobalsetting>
+      </movesetting>
     </edit>
   </language>
 </languages>

--- a/src/AddOn.Episerver.Settings/Resources/Epi.Libraries.Settings.EmbeddedLangFiles_ES.xml
+++ b/src/AddOn.Episerver.Settings/Resources/Epi.Libraries.Settings.EmbeddedLangFiles_ES.xml
@@ -84,6 +84,12 @@
       <deletesetting>
         <deletenotsupported>No se puede eliminar una configuración global</deletenotsupported>
       </deletesetting>
+      <createsetting>
+        <createnotsupported>No se permite crear contenido en la carpeta de configuración global</createnotsupported>
+      </createsetting>
+      <movesetting>
+        <contenttoglobalsetting>No se permite mover contenido a la carpeta de configuración global</contenttoglobalsetting>
+      </movesetting>
     </edit>
   </language>
 </languages>

--- a/src/AddOn.Episerver.Settings/Resources/Epi.Libraries.Settings.EmbeddedLangFiles_FI.xml
+++ b/src/AddOn.Episerver.Settings/Resources/Epi.Libraries.Settings.EmbeddedLangFiles_FI.xml
@@ -84,6 +84,12 @@
       <deletesetting>
         <deletenotsupported>Yleistä asetusta ei voi poistaa</deletenotsupported>
       </deletesetting>
+      <createsetting>
+        <createnotsupported>Sisällön luominen yleisten asetusten kansioon ei ole sallittua</createnotsupported>
+      </createsetting>
+      <movesetting>
+        <contenttoglobalsetting>Sisällön siirtäminen yleisten asetusten kansioon ei ole sallittua</contenttoglobalsetting>
+      </movesetting>
     </edit>
   </language>
 </languages>

--- a/src/AddOn.Episerver.Settings/Resources/Epi.Libraries.Settings.EmbeddedLangFiles_FR.xml
+++ b/src/AddOn.Episerver.Settings/Resources/Epi.Libraries.Settings.EmbeddedLangFiles_FR.xml
@@ -84,6 +84,12 @@
       <deletesetting>
         <deletenotsupported>Un paramètre global ne peut pas être supprimé</deletenotsupported>
       </deletesetting>
+      <createsetting>
+        <createnotsupported>La création de contenu dans le dossier des paramètres globaux n'est pas autorisée</createnotsupported>
+      </createsetting>
+      <movesetting>
+        <contenttoglobalsetting>Le déplacement de contenu dans le dossier des paramètres globaux n'est pas autorisé</contenttoglobalsetting>
+      </movesetting>
     </edit>
   </language>
 </languages>

--- a/src/AddOn.Episerver.Settings/Resources/Epi.Libraries.Settings.EmbeddedLangFiles_IT.xml
+++ b/src/AddOn.Episerver.Settings/Resources/Epi.Libraries.Settings.EmbeddedLangFiles_IT.xml
@@ -84,6 +84,12 @@
       <deletesetting>
         <deletenotsupported>Un'impostazione globale non può essere cancellata</deletenotsupported>
       </deletesetting>
+      <createsetting>
+        <createnotsupported>La creazione di contenuti nella cartella delle impostazioni globali non è consentita</createnotsupported>
+      </createsetting>
+      <movesetting>
+        <contenttoglobalsetting>Lo spostamento del contenuto nella cartella delle impostazioni globali non è consentito</contenttoglobalsetting>
+      </movesetting>
     </edit>
   </language>
 </languages>

--- a/src/AddOn.Episerver.Settings/Resources/Epi.Libraries.Settings.EmbeddedLangFiles_NL.xml
+++ b/src/AddOn.Episerver.Settings/Resources/Epi.Libraries.Settings.EmbeddedLangFiles_NL.xml
@@ -84,6 +84,12 @@
       <deletesetting>
         <deletenotsupported>Globale configuraties kunnen niet verwijderd worden.</deletenotsupported>
       </deletesetting>
+      <createsetting>
+        <createnotsupported>Het maken van inhoud in de map met algemene instellingen is niet toegestaan</createnotsupported>
+      </createsetting>
+      <movesetting>
+        <contenttoglobalsetting>Het verplaatsen van inhoud naar de map met algemene instellingen is niet toegestaan</contenttoglobalsetting>
+      </movesetting>
     </edit>
   </language>
 </languages>

--- a/src/AddOn.Episerver.Settings/Resources/Epi.Libraries.Settings.EmbeddedLangFiles_NO.xml
+++ b/src/AddOn.Episerver.Settings/Resources/Epi.Libraries.Settings.EmbeddedLangFiles_NO.xml
@@ -84,6 +84,12 @@
       <deletesetting>
         <deletenotsupported>En global innstilling kan ikke slettes</deletenotsupported>
       </deletesetting>
+      <createsetting>
+        <createnotsupported>Det er ikke tillatt å lage innhold i mappen for globale innstillinger</createnotsupported>
+      </createsetting>
+      <movesetting>
+        <contenttoglobalsetting>Det er ikke tillatt å flytte innhold til mappen for globale innstillinger</contenttoglobalsetting>
+      </movesetting>
     </edit>
   </language>
 </languages>

--- a/src/AddOn.Episerver.Settings/Resources/Epi.Libraries.Settings.EmbeddedLangFiles_SV.xml
+++ b/src/AddOn.Episerver.Settings/Resources/Epi.Libraries.Settings.EmbeddedLangFiles_SV.xml
@@ -84,6 +84,12 @@
       <deletesetting>
         <deletenotsupported>En global inställning kan inte raderas</deletenotsupported>
       </deletesetting>
+      <createsetting>
+        <createnotsupported>Det är inte tillåtet att skapa innehåll i globala inställningar</createnotsupported>
+      </createsetting>
+      <movesetting>
+        <contenttoglobalsetting>Det är inte tillåtet att flytta innehåll till globala inställningar</contenttoglobalsetting>
+      </movesetting>
     </edit>
   </language>
 </languages>


### PR DESCRIPTION
Also drops the delete handler since the condition for it cancelling the event can never be met. Possibly a left-over that was moved to the move handler.

Resolves: #58