### PR TITLE
Fixes issue where site start is blocked when adding new global setting

### DIFF
--- a/src/AddOn.Episerver.Settings/Core/SettingsInitializationModule.cs
+++ b/src/AddOn.Episerver.Settings/Core/SettingsInitializationModule.cs
@@ -111,14 +111,7 @@ public class SettingsInitializationModule : IConfigurableModule
         siteDefinitionEvents = context.Locate.Advanced.GetInstance<ISiteDefinitionEvents>();
         localizationService = context.Locate.Advanced.GetInstance<LocalizationService>();
         moduleTable = context.Locate.Advanced.GetInstance<ModuleTable>();
-        
-        contentEvents.CreatingContent += CreatingContent;
-        contentEvents.PublishedContent += PublishedContent;
-        contentEvents.MovingContent += MovingContent;
 
-        siteDefinitionEvents.SiteCreated += SiteChanged;
-        siteDefinitionEvents.SiteUpdated += SiteChanged;
-        
         context.InitComplete += InitCompleteHandler;
 
         initialized = true;
@@ -276,5 +269,12 @@ public class SettingsInitializationModule : IConfigurableModule
         }
         
         settingsService.InitSettings();
+        
+        contentEvents.CreatingContent += CreatingContent;
+        contentEvents.PublishedContent += PublishedContent;
+        contentEvents.MovingContent += MovingContent;
+
+        siteDefinitionEvents.SiteCreated += SiteChanged;
+        siteDefinitionEvents.SiteUpdated += SiteChanged;
     }
 }


### PR DESCRIPTION
Moves the hookup of the content events until after the settings init has completed. Trusting that any service code starting early knows what it is doing and is not needed to be verified by the settings event handlers.

Resolves: #65