### PR TITLE
Adds possibility for user to add gadgets to the assets pane

### DIFF
--- a/src/AddOn.Episerver.Settings/AddOn.Episerver.Settings.csproj
+++ b/src/AddOn.Episerver.Settings/AddOn.Episerver.Settings.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>AddOn.Episerver.Settings</RootNamespace>
     <AssemblyName>AddOn.Episerver.Settings</AssemblyName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>5.0.0</PackageVersion>
+    <PackageVersion>5.1.0</PackageVersion>
     <LangVersion>10</LangVersion>
     <TargetFrameworks>net48;net6.0;net7.0</TargetFrameworks>
     <IsPackable>true</IsPackable>

--- a/src/AddOn.Episerver.Settings/UI/SettingsView.cs
+++ b/src/AddOn.Episerver.Settings/UI/SettingsView.cs
@@ -131,7 +131,7 @@ public class SettingsView : ICompositeView,
 
             var tools = new PinnablePane().Add(
             new ComponentPaneContainer
-                    { ContainerType = ContainerType.System }
+                    { ContainerType = ContainerType.User }
                 .Add(new GlobalSharedBlocksComponent().CreateComponent())
                 .Add(new GlobalSettingsVersionsComponent().CreateComponent()));
 
@@ -185,7 +185,7 @@ public class SettingsView : ICompositeView,
     /// <returns>An <see cref="IEnumerable{T}" /> of categories.</returns>
     public IEnumerable<string> GetComponentCategories()
     {
-        return new string[] { };
+        return new [] { "cms", "content" };
     }
 
     /// <summary>


### PR DESCRIPTION
It makes the right side pane into the user type, which allows for saving customization data to the server about which gadgets to have, their sizes and so forth.
Sets the allowed gadget types to be cms and content which is the same as the cms home view.

relates to: #71