### PR TITLE
Update the menu provider to support Opti ID

### DIFF
--- a/src/AddOn.Episerver.Settings/AddOn.Episerver.Settings.csproj
+++ b/src/AddOn.Episerver.Settings/AddOn.Episerver.Settings.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>AddOn.Episerver.Settings</RootNamespace>
     <AssemblyName>AddOn.Episerver.Settings</AssemblyName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>5.1.1</PackageVersion>
+    <PackageVersion>5.1.2</PackageVersion>
     <LangVersion>10</LangVersion>
     <TargetFrameworks>net48;net6.0;net7.0</TargetFrameworks>
     <IsPackable>true</IsPackable>

--- a/src/AddOn.Episerver.Settings/UI/SettingsMenuProvider.cs
+++ b/src/AddOn.Episerver.Settings/UI/SettingsMenuProvider.cs
@@ -23,6 +23,7 @@
 
 using EPiServer.Shell.Navigation;
 using System.Collections.Generic;
+using EPiServer.Shell;
 
 namespace AddOn.Episerver.Settings.UI;
 
@@ -47,10 +48,11 @@ public class SettingsMenuProvider : IMenuProvider
     /// </returns>
     public IEnumerable<MenuItem> GetMenuItems()
     {
+        var url = Paths.ToResource(GetType(), "settings");
         var cmsGlobalSettings = new UrlMenuItem(
         "Global settings",
-        "/global/cms/settings",
-        "/episerver/AddOn.Episerver.Settings/settings")
+        MenuPaths.Global+"/cms/settings",
+         url )
         {
 #if NET48
             IsAvailable = request => PrincipalInfo.HasAdminAccess


### PR DESCRIPTION
Fix issue #76 

The endpoint within the menu provider was hardcoded to 'episerver'; the approach is modified to support Opti ID.