### PR TITLE
Fix Inherited permissions from stopping settings creation

### DIFF
--- a/src/AddOn.Episerver.Settings/AddOn.Episerver.Settings.csproj
+++ b/src/AddOn.Episerver.Settings/AddOn.Episerver.Settings.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>AddOn.Episerver.Settings</RootNamespace>
     <AssemblyName>AddOn.Episerver.Settings</AssemblyName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageVersion>5.1.2</PackageVersion>
+    <PackageVersion>5.1.3</PackageVersion>
     <LangVersion>10</LangVersion>
     <TargetFrameworks>net48;net6.0;net7.0</TargetFrameworks>
     <IsPackable>true</IsPackable>

--- a/src/AddOn.Episerver.Settings/Core/SettingsBase.cs
+++ b/src/AddOn.Episerver.Settings/Core/SettingsBase.cs
@@ -22,13 +22,11 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 using System;
-using System.Linq;
 using EPiServer;
 using EPiServer.Core;
 using EPiServer.DataAnnotations;
 using EPiServer.Security;
 using EPiServer.ServiceLocation;
-using EPiServer.Shell.Services.Rest;
 
 namespace AddOn.Episerver.Settings.Core;
 

--- a/src/AddOn.Episerver.Settings/Core/SettingsBase.cs
+++ b/src/AddOn.Episerver.Settings/Core/SettingsBase.cs
@@ -82,7 +82,8 @@ public class SettingsBase : BasicContent, IVersionable, IContentSecurable
     public IContentSecurityDescriptor GetContentSecurityDescriptor()
     {
         // return any list of valid ACL, for example from Root or StartPage which those settings belong to
-        var accessControlList = (_contentLoader.Service.Get<IContent>(ContentReference.StartPage) as PageData)?.ACL;
+        var contentRef = ContentReference.IsNullOrEmpty(ContentReference.StartPage) ? ContentReference.RootPage : ContentReference.StartPage;
+        var accessControlList = (_contentLoader.Service.Get<IContent>(contentRef) as PageData)?.ACL;
         var writableAccessControlList = accessControlList?.CreateWritableClone();
         // If the ACL is inherited the ACL isn't allowed to be modified.
         if (writableAccessControlList is not null && writableAccessControlList.IsInherited) { 

--- a/src/AddOn.Episerver.Settings/Core/SettingsBase.cs
+++ b/src/AddOn.Episerver.Settings/Core/SettingsBase.cs
@@ -22,11 +22,13 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 using System;
+using System.Linq;
 using EPiServer;
 using EPiServer.Core;
 using EPiServer.DataAnnotations;
 using EPiServer.Security;
 using EPiServer.ServiceLocation;
+using EPiServer.Shell.Services.Rest;
 
 namespace AddOn.Episerver.Settings.Core;
 
@@ -83,8 +85,12 @@ public class SettingsBase : BasicContent, IVersionable, IContentSecurable
     {
         // return any list of valid ACL, for example from Root or StartPage which those settings belong to
         var accessControlList = (_contentLoader.Service.Get<IContent>(ContentReference.StartPage) as PageData)?.ACL;
-
-        return accessControlList?.CreateWritableClone() as IContentSecurityDescriptor;
+        var writableAccessControlList = accessControlList?.CreateWritableClone();
+        // If the ACL is inherited the ACL isn't allowed to be modified.
+        if (writableAccessControlList is not null && writableAccessControlList.IsInherited) { 
+            writableAccessControlList.IsInherited = false;
+        }
+        return writableAccessControlList as IContentSecurityDescriptor;
     }
 }
 


### PR DESCRIPTION
The settings base implements the interface IContentSecurable which requires a ACL to be returned. 

If the ACL is inherited (which happens if the startpage is set to inherit from the root node) it's not possible to create a setting. 