### PR TITLE
Adjust fallback to root page

### DIFF
--- a/src/AddOn.Episerver.Settings/Core/SettingsBase.cs
+++ b/src/AddOn.Episerver.Settings/Core/SettingsBase.cs
@@ -82,7 +82,9 @@ public class SettingsBase : BasicContent, IVersionable, IContentSecurable
     public IContentSecurityDescriptor GetContentSecurityDescriptor()
     {
         // return any list of valid ACL, for example from Root or StartPage which those settings belong to
-        var accessControlList = (_contentLoader.Service.Get<IContent>(ContentReference.StartPage) as PageData)?.ACL;
+        // Fallback to the root page if the wildcard isn't set for the site hostname
+        var aclReference = ContentReference.IsNullOrEmpty(ContentReference.StartPage) ? ContentReference.RootPage : ContentReference.StartPage;
+        var accessControlList = (_contentLoader.Service.Get<IContent>(aclReference) as PageData)?.ACL;
         if (accessControlList is not null && accessControlList.IsInherited)
         {
             accessControlList = (_contentLoader.Service.Get<IContent>(ContentReference.RootPage) as PageData)?.ACL;


### PR DESCRIPTION
I've added a check for ContentReference.StartPage. 

We still need the check after that to see if the startpage inherits permissions from the root page. 