### PR TITLE
Use site definition lookup to use startpage fallback

### DIFF
--- a/src/AddOn.Episerver.Settings/Core/SettingsService.cs
+++ b/src/AddOn.Episerver.Settings/Core/SettingsService.cs
@@ -34,7 +34,6 @@ using EPiServer.Web.Routing;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Reflection;
 
@@ -93,6 +92,11 @@ public class SettingsService : ISettingsService
     private readonly IContentTypeRepository contentTypeRepository;
 
     /// <summary>
+    ///     The site definition resolver
+    /// </summary>
+    private readonly ISiteDefinitionResolver siteDefinitionResolver;
+
+    /// <summary>
     ///     The key used for storing global settings in the synchronized cache
     /// </summary>
     private readonly string globalSettingsCacheKey = "addon.episerver.settings.globalsettings";
@@ -141,11 +145,13 @@ public class SettingsService : ISettingsService
         AncestorReferencesLoader ancestorReferencesLoader,
         ISynchronizedObjectInstanceCache synchronizedObjectInstanceCache,
         IEnumerable<ISettingsResolver> settingsResolvers,
-        IContentRouteHelper contentRouteHelper
+        IContentRouteHelper contentRouteHelper,
+        ISiteDefinitionResolver siteDefinitionResolver
     )
     {
         this.contentRepository = contentRepository;
         this.siteDefinitionRepository = siteDefinitionRepository;
+        this.siteDefinitionResolver = siteDefinitionResolver;
         this.contentRootService = contentRootService;
         this.typeScannerLookup = typeScannerLookup;
         this.contentTypeRepository = contentTypeRepository;
@@ -458,7 +464,11 @@ public class SettingsService : ISettingsService
 
         if (!ancestors.Contains(ContentReference.StartPage, ContentReferenceComparer.IgnoreVersion))
         {
-            ancestors.Add(ContentReference.StartPage);
+            var siteDefinition = siteDefinitionResolver.GetByContent(content.ContentLink, false);
+            if (!ContentReference.IsNullOrEmpty(siteDefinition?.StartPage))
+            {
+                ancestors.Add(siteDefinition.StartPage);
+            }
         }
         
         foreach (var parentReference in ancestors)
@@ -569,7 +579,7 @@ public class SettingsService : ISettingsService
     /// <summary>
     ///     Creates a settings folder for a site and adds it to the settings lookup
     /// </summary>
-    public ContentReference ValidateOrCreateSiteSettingsRoot(SiteDefinition siteDefinition)
+    public ContentReference ValidateOrCreateSiteSettingsRoot(EPiServer.Web.SiteDefinition siteDefinition)
     {
         if (siteDefinition.SiteAssetsRoot.CompareToIgnoreWorkID(siteDefinition.GlobalAssetsRoot))
         {

--- a/src/Addon.Episerver.Settings.Test/SettingsServiceTests.cs
+++ b/src/Addon.Episerver.Settings.Test/SettingsServiceTests.cs
@@ -2,6 +2,7 @@ using AddOn.Episerver.Settings.Core;
 using EPiServer;
 using EPiServer.Core;
 using EPiServer.Framework.Cache;
+using EPiServer.Web;
 using EPiServer.Web.Routing;
 using Moq;
 
@@ -85,6 +86,7 @@ public class SettingsServiceTests
     private SettingsService SetupSettingsService(PageData[] pages, SettingsBase? result)
     {
         var contentRepository = new Mock<IContentRepository>();
+        var siteDefinitionResolver = new Mock<ISiteDefinitionResolver>();
         var ancestorReferencesLoader = new Mock<AncestorReferencesLoader>();
         var settingsResolver = new Mock<ISettingsResolver>();
         var globalSettingsCache = new Mock<ISynchronizedObjectInstanceCache>();
@@ -122,7 +124,8 @@ public class SettingsServiceTests
             ancestorReferencesLoader.Object,
             globalSettingsCache.Object,
             new[] { settingsResolver.Object },
-            null
+            null,
+            siteDefinitionResolver.Object
         );
 
         return settingsService;


### PR DESCRIPTION
As outlined in issue #91, using ContentReference.Startpage which is contextual, you'd get the wrong settings even for ancestorial paths that does not have a setting applied to them